### PR TITLE
feat(rewrite): Add command to rewrite event traces

### DIFF
--- a/cmd/rewrite.go
+++ b/cmd/rewrite.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/specmon/specmon/monitor"
+	"github.com/spf13/cobra"
+)
+
+// RewriteConfig is a configuration of the rewrite subcommand.
+type RewriteConfig struct {
+	JSON bool   `flag:"json" short:"j" desc:"output in json format"`
+	In   string `flag:"in"   short:"i" desc:"input path"`
+	Out  string `flag:"out"  short:"o" desc:"output path"`
+	Pid  int    `flag:"pid"  short:"P" desc:"PID of the monitored process to terminate"`
+}
+
+// RunE runs the rewrite subcommand.
+func (r RewriteConfig) RunE(cmd *cobra.Command, args []string) error {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+
+	var m *monitor.Monitor
+	go func() {
+		<-sigs
+
+		fmt.Fprintln(os.Stderr, "SIGTERM received, exiting...")
+
+		os.Exit(0)
+	}()
+
+	specPath := args[0]
+
+	role, _ := cmd.Root().Flags().GetString("role")
+	decompose, _ := cmd.Root().Flags().GetBool("decompose")
+
+	_, _, decompRules, err := ProcessRules(specPath, role, decompose)
+	if err != nil {
+		return fmt.Errorf("cannot process rules: %w", err)
+	}
+
+	eventSource, err := getEventSource(r.In)
+	if err != nil {
+		return fmt.Errorf("cannot open in file: %w", err)
+	}
+	defer eventSource.Close()
+
+	// events, errs := monitor.ReadEvents(eventSource)
+
+	// go func() {
+	// 	for err := range errs {
+	// 		log.Fatal(err)
+	// 	}
+	// }()
+
+	m, err = monitor.NewMonitor(decompRules)
+	if err != nil {
+		return fmt.Errorf("cannot create monitor: %w", err)
+	}
+
+	// Stats are not reported in the rewrite subcommand.
+	// outs, consumed := m.ProcessEvents(events, true)
+	outs, _ := m.ProcessEventsFromReader(eventSource, true, -1)
+
+	// go func() {
+	// 	for range consumed {
+	// 		continue
+	// 	}
+	// }()
+
+	outFile, err := getOutputFile(r.Out)
+	if err != nil {
+		return fmt.Errorf("cannot open out file: %w", err)
+	}
+	defer outFile.Close()
+
+	for out := range outs {
+		if r.JSON {
+			var b []byte
+
+			b, err = json.Marshal(out)
+			if err != nil {
+				return fmt.Errorf("cannot marshal to json: %w", err)
+			}
+			_, err = fmt.Fprintln(outFile, string(b))
+		} else {
+			_, err = fmt.Fprintln(outFile, out)
+		}
+
+		if err != nil {
+			return fmt.Errorf("cannot write to out file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// NewRewriteCmd creates a new command for the rewrite subcommand.
+func NewRewriteCmd() *cobra.Command {
+	var rewriteConfig RewriteConfig
+
+	cmd := &cobra.Command{
+		Use:   "rewrite",
+		Short: "rewrite the input trace based on the rules",
+		// Long:  `A specification monitor based on multiset-rewrite rules`,
+		RunE: rewriteConfig.RunE,
+		Args: cobra.ExactArgs(1),
+	}
+
+	addFlagsFromStruct(cmd, &rewriteConfig)
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -209,6 +209,7 @@ func Root() *cobra.Command {
 	rootCmd := NewRootCmd()
 	rootCmd.AddCommand(
 		NewMonitorCmd(),
+		NewRewriteCmd(),
 	)
 
 	return rootCmd

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -98,3 +98,13 @@ func getEventSource(file string) (*os.File, error) {
 
 	return os.Open(file)
 }
+
+// getOutputFile returns the output file.
+// If the file is empty or "-", it returns os.Stdout.
+func getOutputFile(file string) (*os.File, error) {
+	if file == "" || file == "-" {
+		return os.Stdout, nil
+	}
+
+	return os.Create(file)
+}


### PR DESCRIPTION
This commit introduces the `rewrite` subcommand, a tool for transforming event traces based on a given specification.

Its primary purpose is to pre-process event streams before they are consumed by the `monitor` command. This allows for the normalization, simplification, or enrichment of complex traces, creating a standardized input for live monitoring.

Key features:
- Processes events from a file specified with the --in flag.
- Outputs the rewritten trace to a file with the --out flag.
- Supports JSON output format for easy integration with other tools.