### PR TITLE
feat(dev): Add Nix flake for reproducible environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 specmon
 tests/
 tags
+
+.direnv
+.envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737125143,
+        "narHash": "sha256-tcq22CtjcAkfAtDSC+E8Wpj8myhNurI0tWmjfJC4jqI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3b028c87cd109accb1311d1a003bc121e18e8bb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Typst Environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShells.default = let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      pkgs.mkShell {
+        buildInputs = [
+          pkgs.go
+	  pkgs.gotools
+	  pkgs.gopls
+	  pkgs.golangci-lint
+        ];
+      };
+    });
+}


### PR DESCRIPTION
This commit introduces a `flake.nix` file to provide a reproducible development environment using Nix.

The flake sets up a shell with the required Go toolchain, including `go`, `gotools`, `gopls`, and `golangci-lint`. It also adds `.direnv` and `.envrc` to the .gitignore to support direnv integration.