### PR TITLE
fix(cmd): Use pointer receivers for command configs

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -39,7 +39,7 @@ type MonitorConfig struct {
 }
 
 // RunE runs the monitor subcommand.
-func (r MonitorConfig) RunE(cmd *cobra.Command, args []string) error {
+func (r *MonitorConfig) RunE(cmd *cobra.Command, args []string) error {
 	quiet, _ := cmd.Root().Flags().GetBool("quiet")
 	pid, err := cmd.Root().Flags().GetInt("pid")
 	if err != nil {

--- a/cmd/rewrite.go
+++ b/cmd/rewrite.go
@@ -38,7 +38,9 @@ type RewriteConfig struct {
 }
 
 // RunE runs the rewrite subcommand.
-func (r RewriteConfig) RunE(cmd *cobra.Command, args []string) error {
+func (r *RewriteConfig) RunE(cmd *cobra.Command, args []string) error {
+	// quiet, _ := cmd.Root().Flags().GetBool("quiet")
+
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGTERM)
 


### PR DESCRIPTION
Changed the `RunE` methods for `MonitorConfig` and `RewriteConfig` to use pointer receivers instead of value receivers.

Using value receivers caused Cobra to populate flags on a copy of the config struct, meaning the values were not available inside the `RunE` methods. Pointer receivers ensure the methods operate on the