### PR TITLE
fix(monitor): Use original event time for rewritten events

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -563,7 +563,7 @@ func (m *Monitor) ProcessEventsFromReader(r io.Reader, rewrite bool, pid int) (<
 						for _, f := range p {
 							if r := getRewriteTerm(f); r != nil {
 								fr := term.Must(term.AsFunction(r))
-								out <- &TimedEvent{Time: /* event.Time */ time.Now().UnixNano(), Event: fr}
+								out <- &TimedEvent{Time: event.Time, Event: fr}
 							}
 						}
 					default:


### PR DESCRIPTION
When rewriting events, the monitor was assigning the current system time (`time.Now()`) as the timestamp for the new event.

This commit changes the logic to preserve the timestamp from the original event (`event.Time`). This ensures that the rewritten trace maintains accurate timing information relative to the source, which is critical for correct latency analysis.