### PR TITLE
chore: Ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 specmon
 tests/
 tags
-
 .direnv
 .envrc
+vendor


### PR DESCRIPTION
Adds the `vendor/` directory to `.gitignore` to prevent vendored Go dependencies from being committed to the repository.