### PR TITLE
fix(rule): Recursively expand formats in facts

### DIFF
--- a/rule/fact.go
+++ b/rule/fact.go
@@ -225,7 +225,7 @@ func (f Facts) ExpandFacts(b *term.Binding) []*Fact {
 		newFact := NewFact(fact.Name, slices.Clone(fact.Args), fact.Type)
 		for j := range newFact.Args {
 			b.Iterate(func(k, v term.Term) bool {
-				newFact.Args[j] = term.UnifyReplace(newFact.Args[j], k, v)
+				newFact.Args[j] = term.UnifyReplaceRecursive(newFact.Args[j], k, v)
 
 				return true
 			})

--- a/term/term.go
+++ b/term/term.go
@@ -762,6 +762,23 @@ func UnifyReplace(t, g, h Term) Term {
 	return u
 }
 
+func UnifyReplaceRecursive(t, g, h Term) Term {
+	current := t
+
+	// Keep applying replacements until no more changes occur
+	for {
+		previous := current
+		current = UnifyReplace(current, g, h)
+
+		// If no changes occurred, we're done
+		if current.Equal(previous) {
+			break
+		}
+	}
+
+	return current
+}
+
 // Find a (sub)term g of t such that p(g) holds and replace it with r(g) in t.
 // Note: t == g is allowed.
 func FindReplaceBy(t Term, p func(Term) bool, r func(Term) Term) Term {


### PR DESCRIPTION
Previously, format macros were only expanded at the top level of a fact's arguments. This meant that formats nested within other terms in an argument, such as in `Fact(f(format(x)))`, were not evaluated.

This commit updates the format expansion logic to traverse the term structure of each argument recursively. This ensures that all format macros are correctly expanded, regardless of their nesting depth.

This fix leads to more correct and predictable behavior when using complex, nested term structures in rule definitions.