### PR TITLE
fix(rule): Safely concatenate fact slices in translation

### DIFF
--- a/rule/translation.go
+++ b/rule/translation.go
@@ -46,7 +46,9 @@ func BuildDAGForRule(r *Rule) *TermNode {
 	// 2. LHS defines all variables in Act and RHS
 	root := data.NewDAGNode[term.Term, term.Term](nil)
 
-	combinedFacts := append(r.RHS, r.Act...)
+	combinedFacts := make([]*Fact, 0, len(r.RHS)+len(r.Act))
+	combinedFacts = append(combinedFacts, r.RHS...)
+	combinedFacts = append(combinedFacts, r.Act...)
 
 	for _, fact := range combinedFacts {
 		for _, arg := range fact.Args {
@@ -259,7 +261,9 @@ func ReplaceSubterms(n *TermNode, b *term.Binding) {
 }
 
 func Translate(r *Rule /*, I data.Set[string]*/) []*Rule {
-	combinedFacts := append(r.RHS, r.Act...)
+	combinedFacts := make([]*Fact, 0, len(r.RHS)+len(r.Act))
+	combinedFacts = append(combinedFacts, r.RHS...)
+	combinedFacts = append(combinedFacts, r.Act...)
 
 	// If the RHS of r does not contain any functions, there is nothing to do.
 	if !Facts(combinedFacts).HasFunctions() {


### PR DESCRIPTION
The previous implementation used `append(r.RHS, r.Act...)` to combine fact slices within the `BuildDAGForRule` and `Translate` functions. This pattern is unsafe and was flagged by the `gocritic` linter.

The `append` built-in may reuse the underlying array of the first slice (`r.RHS`) if it has sufficient capacity. This would cause the resulting `combinedFacts` slice to share its backing array with the original rule's `r.RHS`. Any subsequent modifications to `combinedFacts` could lead to subtle and hard-to-debug side effects, as it would unintentionally mutate the original rule object.

This commit resolves the issue by explicitly creating a new slice with its own backing array and the combined capacity of both slices. This guarantees that the `combinedFacts` slice is independent and prevents any potential memory aliasing bugs.