### PR TITLE
feat(parser): Add Tamarin preprocessor support

### DIFF
--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -64,9 +64,10 @@ func (r *MonitorConfig) RunE(cmd *cobra.Command, args []string) error {
 
 	role, _ := cmd.Root().Flags().GetString("role")
 	decompose, _ := cmd.Root().Flags().GetBool("decompose")
+	defines, _ := cmd.Root().Flags().GetStringSlice("defines")
 
 	// Parse main monitoring rules
-	_, _, decompRules, err := ProcessRules(specPath, role, decompose)
+	_, _, decompRules, err := ProcessRules(specPath, role, decompose, defines)
 	if err != nil {
 		return err
 	}

--- a/cmd/rewrite.go
+++ b/cmd/rewrite.go
@@ -57,8 +57,9 @@ func (r *RewriteConfig) RunE(cmd *cobra.Command, args []string) error {
 
 	role, _ := cmd.Root().Flags().GetString("role")
 	decompose, _ := cmd.Root().Flags().GetBool("decompose")
+	defines, _ := cmd.Root().Flags().GetStringSlice("defines")
 
-	_, _, decompRules, err := ProcessRules(specPath, role, decompose)
+	_, _, decompRules, err := ProcessRules(specPath, role, decompose, defines)
 	if err != nil {
 		return fmt.Errorf("cannot process rules: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,14 +39,15 @@ const (
 
 // RootConfig is the configuration of the root command.
 type RootConfig struct {
-	Verbose        bool   `flag:"verbose"          short:"v" desc:"verbose output"`
-	Quiet          bool   `flag:"quiet"            short:"q" desc:"quiet output"`
-	Decompose      bool   `flag:"decompose"        short:"d" desc:"decompose rules"`
-	LogLevel       string `flag:"log-level"        short:"l" desc:"log level"`
-	Role           string `flag:"role"             short:"r" desc:"role"`
-	SpecPath       string `flag:"spec-path"        short:"s" desc:"specification path"`
-	CPUProfilePath string `flag:"cpu-profile-path" short:"c" desc:"cpu profile path"`
-	MemProfilePath string `flag:"mem-profile-path" short:"m" desc:"memory profile path"`
+	Verbose        bool     `flag:"verbose"          short:"v" desc:"verbose output"`
+	Quiet          bool     `flag:"quiet"            short:"q" desc:"quiet output"`
+	Decompose      bool     `flag:"decompose"        short:"d" desc:"decompose rules"`
+	LogLevel       string   `flag:"log-level"        short:"l" desc:"log level"`
+	Role           string   `flag:"role"             short:"r" desc:"role"`
+	Defines        []string `flag:"defines"          short:"D" desc:"define preprocessor variables"`
+	SpecPath       string   `flag:"spec-path"        short:"s" desc:"specification path"`
+	CPUProfilePath string   `flag:"cpu-profile-path" short:"c" desc:"cpu profile path"`
+	MemProfilePath string   `flag:"mem-profile-path" short:"m" desc:"memory profile path"`
 }
 
 // DefaultRootConfig returns the default configuration of the root command.
@@ -61,7 +62,7 @@ func DefaultRootConfig() *RootConfig {
 // The command parses a specification, and if requested,
 // performs a filtering and decomposition of the rules.
 func (c *RootConfig) RunE() error {
-	rules, selectedRules, decompRules, err := ProcessRules(c.SpecPath, c.Role, c.Decompose)
+	rules, selectedRules, decompRules, err := ProcessRules(c.SpecPath, c.Role, c.Decompose, c.Defines)
 	if err != nil {
 		return err
 	}

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -38,8 +38,8 @@ import (
 )
 
 // ProcessRules parses the rules from the given path and returns the original, the selected and the decomposed rules.
-func ProcessRules(specPath, role string, decompose bool) ([]*rule.Rule, []*rule.Rule, []*rule.Rule, error) {
-	rules, err := parser.ParseRules(context.Background(), specPath)
+func ProcessRules(specPath, role string, decompose bool, defines []string) ([]*rule.Rule, []*rule.Rule, []*rule.Rule, error) {
+	rules, err := parser.ParseFile(context.Background(), specPath, defines)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot process rules: %w", err)
 	}
@@ -90,6 +90,11 @@ func addFlagsFromStruct(cmd *cobra.Command, cfg interface{}) {
 			value := fieldValue.String()
 			// Type is already known due to reflection.
 			cmd.PersistentFlags().StringVarP(fieldValue.Addr().Interface().(*string), flag, short, value, desc) // Set default value
+		case reflect.Slice:
+			if fieldValue.Type().Elem().Kind() == reflect.String {
+				// Handle []string type
+				cmd.PersistentFlags().StringSliceVarP(fieldValue.Addr().Interface().(*[]string), flag, short, nil, desc)
+			}
 		default:
 			// Ignore unsupported fields
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -271,12 +271,31 @@ func (p *Parser) parseFacts(node *sitter.Node, factQuery *sitter.Query, factQuer
 	return facts
 }
 
-func ParseRules(ctx context.Context, filename string) ([]*rule.Rule, error) {
+// ParseFile reads the given file, preprocesses it with the given defines,
+// and parses the rules from it.
+func ParseFile(ctx context.Context, filename string, defines []string) ([]*rule.Rule, error) {
 	src, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, &ParseError{NewParser(filename, nil, nil), err}
 	}
 
+	// First parse for preprocessing
+	initialTree, err := Parse(ctx, src)
+	if err != nil {
+		// Create a parser instance for error reporting
+		p := NewParser(filename, src, spthy.GetLanguage())
+		return nil, &ParseError{p, err}
+	}
+
+	// Preprocess the source code
+	preprocessor := NewPreprocessor(src, defines)
+	preprocessedSrc := preprocessor.Run(initialTree.RootNode())
+
+	// Now, parse the preprocessed source to get the final AST
+	return parseRules(ctx, filename, preprocessedSrc)
+}
+
+func parseRules(ctx context.Context, filename string, src []byte) ([]*rule.Rule, error) {
 	p := NewParser(filename, src, spthy.GetLanguage())
 
 	sitterParser := sitter.NewParser()
@@ -346,6 +365,14 @@ func ParseRules(ctx context.Context, filename string) ([]*rule.Rule, error) {
 	}
 
 	return rules, nil
+}
+
+// Parse parses the given source code and returns a tree-sitter tree.
+func Parse(ctx context.Context, source []byte) (*sitter.Tree, error) {
+	parser := sitter.NewParser()
+	lang := spthy.GetLanguage()
+	parser.SetLanguage(lang)
+	return parser.ParseCtx(ctx, nil, source)
 }
 
 // parseRuleAttributes parses the attributes of a rule node and returns a map of attribute key-value pairs.

--- a/parser/preprocessor.go
+++ b/parser/preprocessor.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"bytes"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Preprocessor holds the state for the preprocessing pass.
+type Preprocessor struct {
+	source  []byte
+	defines map[string]bool
+}
+
+// NewPreprocessor creates a new preprocessor.
+func NewPreprocessor(source []byte, defines []string) *Preprocessor {
+	defs := make(map[string]bool)
+	for _, d := range defines {
+		defs[d] = true
+	}
+	return &Preprocessor{
+		source:  source,
+		defines: defs,
+	}
+}
+
+// Run processes the AST and returns the preprocessed source code.
+func (p *Preprocessor) Run(root *sitter.Node) []byte {
+	var out bytes.Buffer
+	p.walk(root, &out)
+	return out.Bytes()
+}
+
+// walk traverses the AST and writes the processed source to the buffer.
+func (p *Preprocessor) walk(node *sitter.Node, out *bytes.Buffer) {
+	nodeType := node.Type()
+
+	if nodeType == "preprocessor" {
+		// The preprocessor node itself doesn't have content, but it has a child
+		// which is the actual directive, e.g., 'ifdef'.
+		p.handlePreprocessor(node.Child(0), out)
+		return
+	}
+
+	// For all other nodes, we need to preserve the original source content
+	// including whitespace and newlines. We copy the entire range of the node.
+	if node.ChildCount() == 0 {
+		// Leaf node: copy its content
+		out.Write(p.source[node.StartByte():node.EndByte()])
+	} else {
+		// Non-leaf node: recursively walk children, but also preserve
+		// any whitespace between children by tracking byte positions
+		lastEndByte := node.StartByte()
+
+		for i := 0; i < int(node.ChildCount()); i++ {
+			child := node.Child(i)
+
+			// Copy any whitespace/content between the last child and this one
+			if child.StartByte() > lastEndByte {
+				out.Write(p.source[lastEndByte:child.StartByte()])
+			}
+
+			// Process the child
+			p.walk(child, out)
+			lastEndByte = child.EndByte()
+		}
+
+		// Copy any remaining content after the last child
+		if node.EndByte() > lastEndByte {
+			out.Write(p.source[lastEndByte:node.EndByte()])
+		}
+	}
+}
+
+// handlePreprocessor evaluates a preprocessor directive.
+func (p *Preprocessor) handlePreprocessor(node *sitter.Node, out *bytes.Buffer) {
+	if node.Type() == "ifdef" {
+		// Use field-based access instead of child indices
+		conditionNode := node.ChildByFieldName("condition")
+
+		if conditionNode == nil {
+			return // No condition found
+		}
+
+		condition := conditionNode.Content(p.source)
+		if p.defines[condition] {
+			// Condition is true, process all 'consequence' nodes
+			consequenceNodes := childrenByFieldName(node, "consequence")
+			for _, conseqNode := range consequenceNodes {
+				p.walk(conseqNode, out)
+			}
+		} else {
+			// Condition is false, process all 'alternative' nodes if they exist
+			alternativeNodes := childrenByFieldName(node, "alternative")
+			for _, altNode := range alternativeNodes {
+				p.walk(altNode, out)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Introduces support for Tamarin's preprocessor directives in `.spthy` specification files, enabling conditional processing through `#ifdef`, `#else`, and `#endif` constructs. This maintains compatibility with Tamarin's preprocessing capabilities while extending SpecMon's parsing functionality.

This initial implementation supports basic conditional directives without complex conditional formulas, focusing on simple variable-based conditions that align with Tamarin's preprocessor behavior.

The implementation follows a two-pass parsing approach:
- First pass: Parse the original source to handle Tamarin preprocessor directives, generating clean preprocessed source code.
- Second pass: Parse the preprocessed source to build the final rule set.

Key changes include:
- A new `Preprocessor` struct that walks the tree-sitter AST and evaluates Tamarin-style conditional directives based on provided definitions.
- Enhanced `ParseFile` function that orchestrates the two-pass parsing workflow, replacing the original `ParseRules` function.
- Command-line integration via a new `--define`/`-D` flag that accepts multiple preprocessor variables and is available across all subcommands, matching Tamarin's preprocessor interface.
- Extended `addFlagsFromStruct` to support string slice types for automatic flag handling from struct tags.

The preprocessor preserves all original source formatting, whitespace, and newlines by carefully tracking byte positions during AST traversal, ensuring that the preprocessed output remains syntactically valid for the second parsing pass. This maintains full backward compatibility while adding Tamarin's conditional compilation capabilities to SpecMon's specification processing pipeline.