### PR TITLE
fix(rule): Skip decomposition for rules with existing triggers or hints

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -49,7 +49,7 @@ func ProcessRules(specPath, role string, decompose bool, defines []string) ([]*r
 	var decompRules []*rule.Rule
 	if decompose {
 		for _, r := range selectedRules {
-			if !r.NoDecomp() {
+			if !r.NoDecomp() && !r.HasHints() && !r.HasTriggers() {
 				decompRules = append(decompRules, rule.Translate(r)...)
 			} else {
 				decompRules = append(decompRules, r)

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,17 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/smacker/go-tree-sitter v0.0.0-20231219031718-233c2f923ac7
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.7.4
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/testdata/translation/README.md
+++ b/testdata/translation/README.md
@@ -1,0 +1,63 @@
+# Translation Test Cases
+
+This directory contains test cases for testing the rule decomposition/translation functionality.
+
+## Structure
+
+Each test case is a directory under `testdata/translation/` with the following structure:
+
+```
+testdata/translation/
+├── <test_case_name>/
+│   ├── input.spthy          # Original rules to be decomposed
+│   └── expected.spthy       # Expected decomposed rules
+├── README.md                # This documentation (ignored by tests)
+```
+
+**Note**: Only directories are processed as test cases. Files like README.md are automatically ignored.
+
+## Adding New Test Cases
+
+1. Create a new directory under `testdata/translation/` with a descriptive name
+2. Add `input.spthy` with the original rule(s) you want to test
+3. Add `expected.spthy` with the expected decomposed rules
+
+### How to Generate Expected Output
+
+To see what the actual decomposition produces for your input, you can:
+
+1. Temporarily add a debug test in `rule/translation_integration_test.go`:
+
+```go
+func TestDebugNewCase(t *testing.T) {
+    inputFile := "../testdata/translation/your_test_case/input.spthy"
+    _, _, decompRules, err := cmd.ProcessRules(inputFile, "", true, nil)
+    require.NoError(t, err)
+    
+    fmt.Println("Decomposed rules:")
+    for i, rule := range decompRules {
+        fmt.Printf("Rule %d: %s\n", i, rule.String())
+        fmt.Println("---")
+    }
+}
+```
+
+2. Run the test: `go test -v ./rule -run TestDebugNewCase`
+3. Copy the output to create your `expected.spthy` file
+4. Remove the debug test
+
+## Existing Test Cases
+
+- **simple_function**: Tests decomposition of nested function calls `len(hash(m))`
+- **no_decomposition**: Tests rules that don't need decomposition
+- **no_decomp_attribute**: Tests rules with the `[no-decomp]` attribute
+- **existing_triggers**: Tests that rules with existing triggers should NOT be decomposed
+- **existing_hints**: Tests that rules with existing hints should NOT be decomposed
+
+## Running Tests
+
+```bash
+go test -v ./rule -run TestTranslationFromFiles
+```
+
+This will automatically discover and run all test cases in the `testdata/translation/` directory.

--- a/testdata/translation/existing_hints/expected.spthy
+++ b/testdata/translation/existing_hints/expected.spthy
@@ -1,0 +1,9 @@
+theory ExistingHints
+begin
+
+rule TestRuleWithHint [ hint=[<len(y), len_y>] ]:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end

--- a/testdata/translation/existing_hints/input.spthy
+++ b/testdata/translation/existing_hints/input.spthy
@@ -1,0 +1,9 @@
+theory ExistingHints
+begin
+
+rule TestRuleWithHint [ hint=[<len(y), len_y>] ]:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end

--- a/testdata/translation/existing_triggers/expected.spthy
+++ b/testdata/translation/existing_triggers/expected.spthy
@@ -1,0 +1,9 @@
+theory ExistingTriggers
+begin
+
+rule TestRuleWithTrigger [ trigger=[<hash(x), hash_x>] ]:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end

--- a/testdata/translation/existing_triggers/input.spthy
+++ b/testdata/translation/existing_triggers/input.spthy
@@ -1,0 +1,9 @@
+theory ExistingTriggers
+begin
+
+rule TestRuleWithTrigger [ trigger=[<hash(x), hash_x>] ]:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end

--- a/testdata/translation/no_decomp_attribute/expected.spthy
+++ b/testdata/translation/no_decomp_attribute/expected.spthy
@@ -1,0 +1,9 @@
+theory NoDecompAttribute
+begin
+
+rule TestRule [no-decomp]:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end

--- a/testdata/translation/no_decomp_attribute/input.spthy
+++ b/testdata/translation/no_decomp_attribute/input.spthy
@@ -1,0 +1,9 @@
+theory NoDecompAttribute
+begin
+
+rule TestRule [no-decomp]:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end

--- a/testdata/translation/no_decomposition/expected.spthy
+++ b/testdata/translation/no_decomposition/expected.spthy
@@ -1,0 +1,9 @@
+theory NoDecomposition
+begin
+
+rule SimpleRule:
+  [ State0(x) ] 
+  --> 
+  [ State1(x) ]
+
+end

--- a/testdata/translation/no_decomposition/input.spthy
+++ b/testdata/translation/no_decomposition/input.spthy
@@ -1,0 +1,9 @@
+theory NoDecomposition
+begin
+
+rule SimpleRule:
+  [ State0(x) ] 
+  --> 
+  [ State1(x) ]
+
+end

--- a/testdata/translation/simple_function/expected.spthy
+++ b/testdata/translation/simple_function/expected.spthy
@@ -1,0 +1,24 @@
+theory SimpleFunction
+begin
+
+rule TestRule_Start [ hint=[<hash(m), hashm>] ]:
+  [ State0(m) ] 
+  -->
+  [ ST_TestRule_hashm_Pre(<m>) ]
+
+rule TestRule_0 [ trigger=[<len(hashm), lenhashm>] ]:
+  [ ST_TestRule_hashm(<m>, hashm) ] 
+  -->
+  [ ST_TestRule_lenhashm(<m>, len(hashm)) ]
+
+rule TestRule_1 [ trigger=[<hash(m), hashm>] ]:
+  [ ST_TestRule_hashm_Pre(<m>) ] 
+  -->
+  [ ST_TestRule_hashm(<m>, hash(m)) ]
+
+rule TestRule_End:
+  [ ST_TestRule_lenhashm(<m>, lenhashm) ] 
+  -->
+  [ Out(lenhashm), State1(m) ]
+
+end

--- a/testdata/translation/simple_function/input.spthy
+++ b/testdata/translation/simple_function/input.spthy
@@ -1,0 +1,9 @@
+theory SimpleFunction
+begin
+
+rule TestRule:
+  [ State0(m) ] 
+  --> 
+  [ Out(len(hash(m))), State1(m) ]
+
+end


### PR DESCRIPTION
Rules with existing triggers or hints should not be decomposed as they already contain semantic information for event handling. Updates `ProcessRules` to check `!r.HasHints() && !r.HasTriggers()` before attempting translation.

Adds comprehensive file-based tests to validate decomposition behavior and prevent regression of this fix.

Fixes #25