### PR TITLE
chore(ci): Upgrade golangci-lint from v1.63 to v2.5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,9 +41,9 @@ jobs:
           cache-dependency-path: '**/*.sum'
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.63.4
+          version: v2.5
 
       - name: Run tests
         run: go test -v -coverprofile=coverage.out ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,74 +1,78 @@
-# Copyright (C) 2025 CISPA Helmholtz Center for Information Security
-# Author: Kevin Morio <kevin.morio@cispa.de>
-#
-# This file is part of SpecMon.
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with program. If not, see <https://www.gnu.org/licenses/>.
-
+version: "2"
 run:
   timeout: 10m
 linters:
-  enable-all: false
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - errorlint
+    - gocyclo
     - gocritic
-    - gofumpt
-    - goimports
-    - gomodguard
-    - revive
-    - gosimple
-    - govet
-    - gosec
     - godot
+    - gomodguard
+    - gosec
+    - govet
     - ineffassign
+    - ireturn
     - lll
     - misspell
     - nakedret
     - nolintlint
+    - revive
     - staticcheck
     - testifylint
-    - typecheck
     - unconvert
     - unparam
     - unused
-linters-settings:
-  gocyclo:
-    min-complexity: 75
-  lll:
-    line-length: 200
-  ireturn:
-    allow:
-      - error
-      - generic
-      - Term
-  mnd:
-    ignored-numbers:
-      - '0'
-      - '1'
-      - '2'
-  gocritic:
-    disabled-checks:
-      - captLocal 
-      - unslice
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - lll
-    - path: binding.go
-      linters:
-        - gocritic
+  settings:
+    gocritic:
+      disabled-checks:
+        - captLocal
+        - unslice
+    gocyclo:
+      min-complexity: 75
+    ireturn:
+      allow:
+        - error
+        - generic
+        - stdlib
+        - Term
+    lll:
+      line-length: 200
+    mnd:
+      ignored-numbers:
+        - "0"
+        - "1"
+        - "2"
+    revive:
+      rules:
+        - name: var-naming
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        path: _test\.go
+      - linters:
+          - gocritic
+        path: binding.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/benchmarks/int_to_bytes_test.go
+++ b/benchmarks/int_to_bytes_test.go
@@ -69,9 +69,9 @@ func main() {
 	if err != nil {
 		fmt.Println("Error:", err)
 	} else {
-		fmt.Println("Original:", bytes)
+		fmt.Println("Original:", string(bytes))
 	}
 
 	optimizedBytes := IntToBytesOptimized(12345678, binary.BigEndian)
-	fmt.Println("Optimized:", optimizedBytes)
+	fmt.Println("Optimized:", string(optimizedBytes))
 }

--- a/data/dag.go
+++ b/data/dag.go
@@ -240,9 +240,10 @@ func (d *DAGNode[V, E]) Traverse(dir TraversalDirection, typ TraversalType, visi
 
 		var label E
 		if P[n] != nil {
-			if dir == TraverseDown {
+			switch dir {
+			case TraverseDown:
 				label = P[n].Label(n)
-			} else if dir == TraverseUp {
+			case TraverseUp:
 				label = n.Label(P[n])
 			}
 		}

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737125143,
-        "narHash": "sha256-tcq22CtjcAkfAtDSC+E8Wpj8myhNurI0tWmjfJC4jqI=",
+        "lastModified": 1760527613,
+        "narHash": "sha256-AGdZ+tZgDP0IP+KN2zt29U15m2ACz60WgrgiITOKHbw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b028c87cd109accb1311d1a003bc121e18e8bb1",
+        "rev": "2f5d84dd15f512c1ea8d2bf52d66a1ed20577e10",
         "type": "github"
       },
       "original": {

--- a/rule/translation_integration_test.go
+++ b/rule/translation_integration_test.go
@@ -56,7 +56,7 @@ func TestTranslationFromFiles(t *testing.T) {
 
 // assertRulesEqual compares two rule slices, handling ordering and formatting differences.
 func assertRulesEqual(t *testing.T, expected, actual []*rule.Rule) {
-	require.Equal(t, len(expected), len(actual), "Different number of rules")
+	require.Len(t, actual, len(expected), "Different number of rules")
 
 	// Sort rules by name for consistent comparison
 	sortRulesByName := func(rules []*rule.Rule) []*rule.Rule {
@@ -80,11 +80,11 @@ func assertRulesEqual(t *testing.T, expected, actual []*rule.Rule) {
 			"Rule %d: Name mismatch", i)
 
 		// Compare LHS, Act, RHS lengths
-		require.Equal(t, len(expectedRule.LHS), len(actualRule.LHS),
+		require.Len(t, actualRule.LHS, len(expectedRule.LHS),
 			"Rule %s: LHS length mismatch", expectedRule.Name)
-		require.Equal(t, len(expectedRule.Act), len(actualRule.Act),
+		require.Len(t, actualRule.Act, len(expectedRule.Act),
 			"Rule %s: Act length mismatch", expectedRule.Name)
-		require.Equal(t, len(expectedRule.RHS), len(actualRule.RHS),
+		require.Len(t, actualRule.RHS, len(expectedRule.RHS),
 			"Rule %s: RHS length mismatch", expectedRule.Name)
 
 		// For more detailed comparison, we could implement structural equality.


### PR DESCRIPTION
Migrate to golangci-lint v2.5 with updated configuration format and CI integration. This includes enabling additional linters and resolving new linting errors introduced by the stricter checks.

- Update golangci-lint-action from v6 to v8
- Migrate configuration to v2 format with timeout setting
- Enable gocyclo and ireturn linters with appropriate settings
- Disable overly-strict revive var-naming rule
- Fix linting errors in benchmarks, data, and rule packages