### PR TITLE
fix(term): Enforce exact byte length in format parsing

### DIFF
--- a/term/format.go
+++ b/term/format.go
@@ -38,6 +38,7 @@ const (
 var (
 	ErrVariableInField   = errors.New("field contains a variable")
 	ErrSliceTooShort     = errors.New("byte slice too short")
+	ErrSliceTooLong      = errors.New("byte slice too long: not all bytes consumed")
 	ErrByteConversion    = errors.New("cannot convert bytes to constant")
 	ErrVariableRedefined = errors.New("variable already defined")
 	ErrConstantsNoMatch  = errors.New("constants do not match")
@@ -113,6 +114,11 @@ func ParseFormat(fields []*Function, s []byte) (*Binding, error) {
 
 		// Move to the next field in the byte slice.
 		n += length
+	}
+
+	// Ensure all bytes have been consumed to avoid matching formats with different lengths
+	if n != len(s) {
+		return nil, ErrSliceTooLong
 	}
 
 	return b, nil

--- a/term/format_conflict_test.go
+++ b/term/format_conflict_test.go
@@ -1,0 +1,191 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package term_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/specmon/specmon/term"
+)
+
+// TestFormatLengthConflict is a regression test for a critical bug where format
+// patterns with different total length constraints could incorrectly unify with
+// the same byte data, leading to ambiguous matches.
+//
+// Bug scenario:
+// - Pattern A expects cat(byte(x, 2), byte(y, 3)) - total 5 bytes
+// - Pattern B expects cat(byte(x, 2), byte(y, 5)) - total 7 bytes
+// - Incoming data has 7 bytes
+//
+// Before fix: ParseFormat didn't properly validate that all bytes were consumed,
+// allowing Pattern A to match the first 5 bytes of a 7-byte input. This caused
+// both patterns to appear valid during unification in the monitor's conflictSet,
+// leading to "cannot delete non-existing fact" errors when rules tried to apply.
+//
+// After fix: ParseFormat returns ErrSliceTooLong if not all bytes are consumed,
+// ensuring only exact-length matches succeed. Pattern A fails on 7-byte data;
+// only Pattern B succeeds.
+func TestFormatLengthConflict(t *testing.T) {
+	t.Parallel()
+
+	// Pattern 1: expects exactly 5 bytes total
+	shortPattern := []*term.Function{
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("x"),
+			term.NewConstant[int](2),
+		}))),
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("y"),
+			term.NewConstant[int](3),
+		}))),
+	}
+
+	// Pattern 2: expects exactly 7 bytes total
+	longPattern := []*term.Function{
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("x"),
+			term.NewConstant[int](2),
+		}))),
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("y"),
+			term.NewConstant[int](5),
+		}))),
+	}
+
+	// Test data: 7 bytes
+	sevenBytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+
+	// Short pattern should FAIL on 7-byte data (too many bytes)
+	_, err := term.ParseFormat(shortPattern, sevenBytes)
+	if !errors.Is(err, term.ErrSliceTooLong) {
+		t.Errorf("shortPattern on 7 bytes: expected ErrSliceTooLong, got %v", err)
+	}
+
+	// Long pattern should SUCCEED on 7-byte data
+	binding, err := term.ParseFormat(longPattern, sevenBytes)
+	if err != nil {
+		t.Errorf("longPattern on 7 bytes: expected success, got %v", err)
+	}
+	if binding == nil {
+		t.Fatal("longPattern on 7 bytes: expected non-nil binding")
+	}
+
+	// Verify the binding contains correct values
+	xVar := term.NewVariable("x")
+	yVar := term.NewVariable("y")
+
+	expectedX := term.NewConstant[[]byte]([]byte{0x01, 0x02})
+	expectedY := term.NewConstant[[]byte]([]byte{0x03, 0x04, 0x05, 0x06, 0x07})
+
+	if boundX, ok := binding.Get(xVar); !ok || !boundX.Equal(expectedX) {
+		t.Errorf("x binding incorrect: got %v, expected %v", boundX, expectedX)
+	}
+	if boundY, ok := binding.Get(yVar); !ok || !boundY.Equal(expectedY) {
+		t.Errorf("y binding incorrect: got %v, expected %v", boundY, expectedY)
+	}
+}
+
+// TestFormatLengthConflict_ShortData tests the opposite case: data that's too
+// short should fail to match longer format patterns.
+func TestFormatLengthConflict_ShortData(t *testing.T) {
+	t.Parallel()
+
+	// Pattern expects 7 bytes total
+	longPattern := []*term.Function{
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("x"),
+			term.NewConstant[int](2),
+		}))),
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("y"),
+			term.NewConstant[int](5),
+		}))),
+	}
+
+	// Test data: only 5 bytes (too short)
+	fiveBytes := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+
+	// Should fail with ErrSliceTooShort
+	_, err := term.ParseFormat(longPattern, fiveBytes)
+	if !errors.Is(err, term.ErrSliceTooShort) {
+		t.Errorf("longPattern on 5 bytes: expected ErrSliceTooShort, got %v", err)
+	}
+}
+
+// TestFormatExactMatch verifies that patterns match only when the length is exact.
+func TestFormatExactMatch(t *testing.T) {
+	t.Parallel()
+
+	pattern := []*term.Function{
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("x"),
+			term.NewConstant[int](3),
+		}))),
+		term.Must(term.AsFunction(term.NewFunction("byte", []term.Term{
+			term.NewVariable("y"),
+			term.NewConstant[int](2),
+		}))),
+	}
+
+	testCases := []struct {
+		name      string
+		data      []byte
+		shouldErr bool
+		errType   error
+	}{
+		{
+			name:      "exact length (5 bytes)",
+			data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05},
+			shouldErr: false,
+		},
+		{
+			name:      "too short (4 bytes)",
+			data:      []byte{0x01, 0x02, 0x03, 0x04},
+			shouldErr: true,
+			errType:   term.ErrSliceTooShort,
+		},
+		{
+			name:      "too long (6 bytes)",
+			data:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			shouldErr: true,
+			errType:   term.ErrSliceTooLong,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			binding, err := term.ParseFormat(pattern, tc.data)
+			if tc.shouldErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if tc.errType != nil && !errors.Is(err, tc.errType) {
+					t.Errorf("expected error %v, got %v", tc.errType, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected success, got error: %v", err)
+				}
+				if binding == nil {
+					t.Error("expected non-nil binding on success")
+				}
+			}
+		})
+	}
+}

--- a/term/format_test.go
+++ b/term/format_test.go
@@ -20,6 +20,7 @@ package term_test
 
 import (
 	"encoding/hex"
+	"errors"
 	"strings"
 	"testing"
 
@@ -592,3 +593,101 @@ func TestFormatToBytes(t *testing.T) {
 	}
 }
 */
+
+// TestFormatLengthConstraint tests that format parsing enforces exact length matching.
+// This is a regression test for a bug where patterns with different byte lengths
+// could incorrectly unify, causing "cannot delete non-existing fact" errors during monitoring.
+func TestFormatLengthConstraint(t *testing.T) {
+	t.Parallel()
+
+	// Create a format pattern: cat(byte(x, 2), byte(y, 3))
+	// This should only match exactly 5 bytes
+	pattern := term.NewFunction("cat", []term.Term{
+		term.NewFunction("byte", []term.Term{
+			term.NewVariable("x"),
+			term.NewConstant[int](2),
+		}),
+		term.NewFunction("byte", []term.Term{
+			term.NewVariable("y"),
+			term.NewConstant[int](3),
+		}),
+	})
+
+	// Test case 1: Exact match (5 bytes) - should succeed
+	t.Run("ExactMatch", func(t *testing.T) {
+		data := term.NewConstant[[]byte]([]byte{0x01, 0x02, 0x03, 0x04, 0x05})
+		_, err := pattern.Unify(data)
+		if err != nil {
+			t.Errorf("Expected successful unification for exact match, got error: %v", err)
+		}
+	})
+
+	// Test case 2: Too short (4 bytes) - should fail
+	t.Run("TooShort", func(t *testing.T) {
+		data := term.NewConstant[[]byte]([]byte{0x01, 0x02, 0x03, 0x04})
+		_, err := pattern.Unify(data)
+		if err == nil {
+			t.Error("Expected unification to fail for too short data, but it succeeded")
+		}
+		// Error is wrapped as ErrInvalidFormat during unification
+		if !errors.Is(err, term.ErrInvalidFormat) {
+			t.Errorf("Expected ErrInvalidFormat, got: %v", err)
+		}
+	})
+
+	// Test case 3: Too long (7 bytes) - should fail
+	// This is the bug we're fixing: extra bytes should cause failure
+	t.Run("TooLong", func(t *testing.T) {
+		data := term.NewConstant[[]byte]([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07})
+		_, err := pattern.Unify(data)
+		if err == nil {
+			t.Error("Expected unification to fail for too long data, but it succeeded")
+		}
+		// Error is wrapped as ErrInvalidFormat during unification
+		if !errors.Is(err, term.ErrInvalidFormat) {
+			t.Errorf("Expected ErrInvalidFormat, got: %v", err)
+		}
+	})
+
+	// Test case 4: Multiple patterns with different lengths should not cross-match
+	t.Run("DifferentLengthPatterns", func(t *testing.T) {
+		// Pattern 1: cat(byte(a, 2), byte(b, 3)) = 5 bytes total
+		pattern1 := term.NewFunction("cat", []term.Term{
+			term.NewFunction("byte", []term.Term{
+				term.NewVariable("a"),
+				term.NewConstant[int](2),
+			}),
+			term.NewFunction("byte", []term.Term{
+				term.NewVariable("b"),
+				term.NewConstant[int](3),
+			}),
+		})
+
+		// Pattern 2: cat(byte(a, 2), byte(b, 5)) = 7 bytes total
+		pattern2 := term.NewFunction("cat", []term.Term{
+			term.NewFunction("byte", []term.Term{
+				term.NewVariable("a"),
+				term.NewConstant[int](2),
+			}),
+			term.NewFunction("byte", []term.Term{
+				term.NewVariable("b"),
+				term.NewConstant[int](5),
+			}),
+		})
+
+		// Data with 7 bytes
+		data := term.NewConstant[[]byte]([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07})
+
+		// pattern1 (5 bytes) should NOT match data (7 bytes)
+		_, err1 := pattern1.Unify(data)
+		if err1 == nil {
+			t.Error("Pattern expecting 5 bytes incorrectly matched 7 bytes of data")
+		}
+
+		// pattern2 (7 bytes) SHOULD match data (7 bytes)
+		_, err2 := pattern2.Unify(data)
+		if err2 != nil {
+			t.Errorf("Pattern expecting 7 bytes should match 7 bytes of data, got error: %v", err2)
+		}
+	})
+}


### PR DESCRIPTION
Adds strict validation to ensure format patterns consume all bytes in the input slice. Previously, ParseFormat only checked if the slice was long enough, allowing patterns to match prefixes of longer data.

This caused multiple format patterns with different lengths to incorrectly unify with the same data, leading to "cannot delete non-existing fact" errors when the monitor tried to consume facts that were already deleted by a different rule instance.

Completes the fix for #22 (second scenario). The first scenario was addressed in #34.

Changes:
- Add ErrSliceTooLong check after parsing all format fields
- Add regression test in monitor/format_conflict_test.go