### PR TITLE
perf(term): Optimize unification performance

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -334,6 +334,10 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 
 		D := data.NewHashSet[RuleApplication]()
 		for _, rr := range rules[aName] {
+			// Skip rules without triggers - we only want to apply trigger rules here
+			if !rr.HasTriggers() {
+				continue
+			}
 			next, err := handleTriggers(d, g, rr, rules)
 			if err != nil {
 				return nil, err
@@ -452,8 +456,11 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 
 	// Track which items from the original items slice have been used.
 	// This ensures multiset semantics s.t. each fact can only be consumed once.
-	var dfs func(pos int, b *term.Binding, usedItems map[int]bool)
-	dfs = func(pos int, b *term.Binding, usedItems map[int]bool) {
+	// Use backtracking (mark/unmark) instead of copying map on each recursive call.
+	usedItems := make(map[int]bool)
+
+	var dfs func(pos int, b *term.Binding)
+	dfs = func(pos int, b *term.Binding) {
 		if pos == n {
 			result.Add(b)
 			return
@@ -472,18 +479,16 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 
 			f := items[itemIdx]
 			if delta, err := f.Unify(ps); err == nil {
-				// Create new used items map with this item marked as used
-				newUsedItems := make(map[int]bool)
-				for k, v := range usedItems {
-					newUsedItems[k] = v
-				}
-				newUsedItems[itemIdx] = true
-				dfs(pos+1, delta.Extend(b), newUsedItems)
+				// Mark item as used (backtracking pattern)
+				usedItems[itemIdx] = true
+				dfs(pos+1, delta.Extend(b))
+				// Unmark item for other branches
+				delete(usedItems, itemIdx)
 			}
 		}
 	}
 
-	dfs(0, term.NewBinding(), make(map[int]bool))
+	dfs(0, term.NewBinding())
 	return result
 }
 

--- a/rule/fact.go
+++ b/rule/fact.go
@@ -119,7 +119,9 @@ func (f *Fact) Unify(other *Fact) (*term.Binding, error) {
 		return nil, ErrFactUnify
 	}
 
-	b := term.NewBinding()
+	// Optimization: collect all non-empty partial bindings to avoid repeated Extend() operations
+	// Skip empty bindings since they don't contribute anything
+	var partials []*term.Binding
 
 	for i, a := range f.Args {
 		b1, err := a.Unify(other.Args[i])
@@ -127,8 +129,21 @@ func (f *Fact) Unify(other *Fact) (*term.Binding, error) {
 			// return nil, fmt.Errorf("cannot unify %s and %s: %w", f, other, err)
 			return nil, ErrFactUnify
 		}
+		// Only collect non-empty bindings
+		if b1.Size() > 0 {
+			partials = append(partials, b1)
+		}
+	}
 
-		b = b.Extend(b1)
+	// Fast path: if no bindings were created, return empty binding
+	if len(partials) == 0 {
+		return term.NewBinding(), nil
+	}
+
+	// Now merge all bindings at once
+	b := term.NewBinding()
+	for _, partial := range partials {
+		b = b.Extend(partial)
 	}
 
 	return b, nil

--- a/term/term.go
+++ b/term/term.go
@@ -646,34 +646,56 @@ func (e *UnificationError) Error() string {
 }
 
 func unify(a1, a2 Term, b *Binding) error {
+	// Fast path: check types first before expensive Equal()
+	t1Type := a1.GetType()
+	t2Type := a2.GetType()
+
+	// Early termination for obviously incompatible types
+	if t1Type == ConstantType && t2Type == ConstantType {
+		// For constants, Equal is relatively cheap, do it early
+		if !a1.Equal(a2) {
+			return ErrConstantsNoMatch
+		}
+		return nil
+	}
+
+	// For functions, check name/arity before full equality
+	if t1Type == FunctionType && t2Type == FunctionType {
+		f1 := Must(AsFunction(a1))
+		f2 := Must(AsFunction(a2))
+
+		// Quick rejection: name or arity mismatch
+		if f1.Name != f2.Name || len(f1.Args) != len(f2.Args) {
+			return ErrNameOrArgMismatch
+		}
+
+		// Now check full equality (which recurses into args)
+		if a1.Equal(a2) {
+			return nil
+		}
+
+		// Not equal but compatible, continue with unification
+		for i := range f1.Args {
+			if err := unify(f1.Args[i], f2.Args[i], b); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// For other combinations, do standard equality check
 	if a1.Equal(a2) {
 		return nil
 	}
 
 	switch {
-	case a1.GetType() == FunctionType && a2.GetType() == FunctionType:
-		// Two functions are unifiable if
-		// - they have the same name and
-		// - number of arguments and
-		// - their arguments are unifiable.
-		t1 := Must(AsFunction(a1))
-		t2 := Must(AsFunction(a2))
-
-		if t1.Name != t2.Name || len(t1.Args) != len(t2.Args) {
-			// return &UnificationError{a1, a2, "name or number of arguments do not match"}
-			return ErrNameOrArgMismatch
-		}
-
-		for i := range t1.Args {
-			if err := unify(t1.Args[i], t2.Args[i], b); err != nil {
-				// return &UnificationError{a1, a2, err.Error()}
-				return err
-			}
-		}
-	case a1.GetType() == FunctionType && a2.GetType() == VariableType:
+	case t1Type == FunctionType && t2Type == FunctionType:
+		// Already handled above
+		return nil
+	case t1Type == FunctionType && t2Type == VariableType:
 		// Swap the order of the terms and try again.
 		return unify(a2, a1, b)
-	case a1.GetType() == FunctionType && a2.GetType() == ConstantType:
+	case t1Type == FunctionType && t2Type == ConstantType:
 		// A function is unifiable with a constant if
 		// - the function is a format and
 		// - the evaluated format is equal to the constant.
@@ -715,10 +737,10 @@ func unify(a1, a2 Term, b *Binding) error {
 		})
 
 		return nil
-	case a1.GetType() == ConstantType && (a2.GetType() == FunctionType || a2.GetType() == VariableType):
+	case t1Type == ConstantType && (t2Type == FunctionType || t2Type == VariableType):
 		// Swap the order of the terms and try again.
 		return unify(a2, a1, b)
-	case a1.GetType() == VariableType:
+	case t1Type == VariableType:
 		v := Must(AsVariable(a1))
 
 		if slices.Contains(Vars(a2), v) {
@@ -733,12 +755,9 @@ func unify(a1, a2 Term, b *Binding) error {
 		})
 
 		b.Set(v, a2)
-	case a1.GetType() == ConstantType && a2.GetType() == ConstantType:
-		// Two constants are unifiable if they are equal.
-		if !a1.Equal(a2) {
-			// return &UnificationError{a1, a2, "constants are not equal"}
-			return ErrConstantsNoMatch
-		}
+	case t1Type == ConstantType && t2Type == ConstantType:
+		// Already handled at the top with early termination
+		return nil
 	default:
 		return ErrUnknownType
 	}


### PR DESCRIPTION
Improve unification performance by reducing allocations and adding fast-path checks. The unification algorithm is critical for rule matching and was performing redundant operations that impacted monitoring performance, especially with large rule sets.

Changes:
- Add fast paths in `term.Unify()` to avoid expensive `Equal()` calls
- Reorder checks to perform quick rejections before deep equality
- Optimize `Fact.Unify()` to batch non-empty bindings instead of extending incrementally, reducing repeated `Extend()` operations
- Optimize `conflictSet()` to use backtracking instead of copying the usedItems map on each recursive call, reducing allocations
- Skip non-trigger rules in `handleHints()` to avoid extra processing