### PR TITLE
fix(rule): Include public LHS variables in decomposed state facts

### DIFF
--- a/rule/translation.go
+++ b/rule/translation.go
@@ -126,6 +126,14 @@ func GenerateEndRule(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding)
 		if retVar := D.Label(d); retVar != nil {
 			fVars := nonPublicRuleVars(r)
 
+			// Add all public variables from the original rule's LHS
+			lhsVars := utils.Unique(Facts(r.LHS).Vars())
+			for _, v := range lhsVars {
+				if v.IsPublic() {
+					fVars = append(fVars, v)
+				}
+			}
+
 			// Find orignal function in F and add public variables to the fact.
 			F.IterateSorted(func(k, v term.Term) bool {
 				if v.Equal(retVar) {


### PR DESCRIPTION
The `GenerateEndRule` function was omitting public variables (prefixed with `$`) that appeared directly as LHS fact arguments during rule decomposition. This caused `expected ground rule, got variables` errors when applying rules that relied on these public variables for binding.

The function correctly included non-public LHS variables and attempted to add public variables found within function applications in the binding, but missed public variables appearing directly as fact arguments (e.g., `B_initMsgIntermediate(..., $B, $A)`).

This resulted in decomposed end rules with incomplete state tuples that lacked the public variables needed for proper unification during monitoring.

Changes:
- Add explicit collection of all public LHS variables before binding iteration in `GenerateEndRule`
- Ensure public variables are included in decomposed state fact tuples alongside non-public variables
- Maintain existing logic for function-embedded public variables