### PR TITLE
fix(monitor): Allow other rules when restriction check fails

### DIFF
--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -20,6 +20,7 @@ package monitor
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"slices"
@@ -223,6 +224,10 @@ func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, error) {
 
 	// Check if special event restrictions are satisfied.
 	if err := restrSatisfied(t.Act); err != nil {
+		// Don't wrap restriction violations to avoid redundant error messages
+		if errors.Is(err, ErrRestrictionViolated) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("rule not applied: %w", err)
 	}
 
@@ -266,14 +271,14 @@ func restrSatisfied(trace []*rule.Fact) error {
 				return fmt.Errorf("event restriction: %s must have two arguments", t.Name)
 			}
 			if !t.Args[0].Equal(t.Args[1]) {
-				return fmt.Errorf("event restriction violated: %s", t)
+				return fmt.Errorf("%w: %s", ErrRestrictionViolated, t)
 			}
 		case "Neq", "NotEqual", "Unequal":
 			if len(t.Args) != 2 {
 				return fmt.Errorf("event restriction: %s must have two arguments", t.Name)
 			}
 			if t.Args[0].Equal(t.Args[1]) {
-				return fmt.Errorf("event restriction violated: %s", t)
+				return fmt.Errorf("%w: %s", ErrRestrictionViolated, t)
 			}
 		}
 	}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -48,7 +48,10 @@ const (
 	consumedChanSize = 4096
 )
 
-var ErrNoApplicableRule = errors.New("no applicable rule found")
+var (
+	ErrNoApplicableRule    = errors.New("no applicable rule found")
+	ErrRestrictionViolated = errors.New("restriction violated")
+)
 
 type Unifier[T any] interface {
 	fmt.Stringer
@@ -294,6 +297,9 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 				}
 
 				C.Add(RuleApplication{r, withTrigger, e})
+			} else if errors.Is(err, ErrRestrictionViolated) {
+				log.Infof("rule %s not applicable due to restriction: %v", r.Name, err)
+				continue
 			} else {
 				return nil, err
 			}
@@ -326,6 +332,10 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 
 		d, err := c.ApplyRule(r, hb)
 		if err != nil {
+			if errors.Is(err, ErrRestrictionViolated) {
+				log.Infof("hint rule %s not applicable due to restriction: %v", r.Name, err)
+				continue
+			}
 			return nil, err
 		}
 

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -94,3 +94,143 @@ func TestMonitorMultipleFrFacts(t *testing.T) {
 
 	t.Logf("Processed event successfully, got %d result configs", len(resultConfigs))
 }
+
+// TestMonitorRestrictionViolation tests that when multiple rules can match an event
+// but one fails due to a restriction violation (e.g., Eq check), the monitor continues
+// to try other rules instead of returning an error immediately.
+func TestMonitorRestrictionViolation(t *testing.T) {
+	// Create an In rule that adds In(x) to state
+	inRule := &rule.Rule{
+		Name: "In",
+		LHS:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("In", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("in", []term.Term{}),
+						term.NewVariable("x"),
+					}),
+				},
+			},
+		},
+	}
+
+	// Create rule A: consumes In($x) with restriction Eq($x, '1')
+	ruleA := &rule.Rule{
+		Name: "A",
+		LHS: []*rule.Fact{
+			rule.NewFact("In", []term.Term{term.NewVariable("$x")}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{
+			rule.NewFact("A", []term.Term{
+				term.NewFunction("h", []term.Term{term.NewVariable("$x")}),
+			}, rule.LinearFact),
+		},
+		Act: []*rule.Fact{
+			rule.NewFact("Eq", []term.Term{
+				term.NewVariable("$x"),
+				term.NewConstant("1"),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("h", []term.Term{term.NewVariable("$x")}),
+						term.NewVariable("h$x"),
+					}),
+				},
+			},
+		},
+	}
+
+	// Create rule B: consumes In($x) with restriction Eq($x, '2')
+	ruleB := &rule.Rule{
+		Name: "B",
+		LHS: []*rule.Fact{
+			rule.NewFact("In", []term.Term{term.NewVariable("$x")}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{
+			rule.NewFact("B", []term.Term{
+				term.NewFunction("h", []term.Term{term.NewVariable("$x")}),
+			}, rule.LinearFact),
+		},
+		Act: []*rule.Fact{
+			rule.NewFact("Eq", []term.Term{
+				term.NewVariable("$x"),
+				term.NewConstant("2"),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("h", []term.Term{term.NewVariable("$x")}),
+						term.NewVariable("h$x"),
+					}),
+				},
+			},
+		},
+	}
+
+	// Create monitor with all three rules
+	mon, err := monitor.NewMonitor([]*rule.Rule{inRule, ruleA, ruleB})
+	if err != nil {
+		t.Fatalf("Failed to create monitor: %v", err)
+	}
+
+	// Process first event: <in(), 1>
+	inEvent := term.NewFunction("pair", []term.Term{
+		term.NewFunction("in", []term.Term{}),
+		term.NewConstant("1"),
+	})
+
+	err = mon.ProcessEvent(inEvent)
+	if err != nil {
+		t.Fatalf("ProcessEvent failed for in event: %v", err)
+	}
+
+	// Process second event: <h(1), 42>
+	hEvent := term.NewFunction("pair", []term.Term{
+		term.NewFunction("h", []term.Term{term.NewConstant("1")}),
+		term.NewConstant("42"),
+	})
+
+	err = mon.ProcessEvent(hEvent)
+	if err != nil {
+		t.Fatalf("ProcessEvent failed for h event: %v", err)
+	}
+
+	// Check the resulting configurations
+	resultConfigs := mon.Configs()
+	if len(resultConfigs) != 1 {
+		t.Fatalf("Expected 1 configuration, got %d", len(resultConfigs))
+	}
+
+	// Verify that rule A was applied (fact A exists) and rule B was not (fact B doesn't exist)
+	config := resultConfigs[0]
+	facts := config.Facts()
+
+	foundA := false
+	foundB := false
+	for _, fact := range facts {
+		if fact.Name == "A" {
+			foundA = true
+		}
+		if fact.Name == "B" {
+			foundB = true
+		}
+	}
+
+	if !foundA {
+		t.Errorf("Expected fact A to exist (rule A should have succeeded)")
+	}
+	if foundB {
+		t.Errorf("Expected fact B to not exist (rule B should have failed due to restriction)")
+	}
+
+	t.Logf("Test passed: Rule A succeeded, Rule B failed due to restriction violation")
+}


### PR DESCRIPTION
When multiple rules could match an event, previously if one rule's restriction (e.g., `Eq` check) failed, ProcessEvent would immediately return an error, preventing other potentially applicable rules from being evaluated.

This fix introduces `ErrRestrictionViolated` to distinguish restriction failures from other errors, allowing the monitor to continue trying alternative rules when one fails due to unmet restrictions.

Changes:
- Add `ErrRestrictionViolated` error type to monitor package
- Update `handleTriggers` and `handleHints` to continue on restriction violations
- Simplify restriction violation error messages to avoid redundancy
- Add test coverage for multiple rules with conflicting restrictions