### PR TITLE
feat(monitor): Add XOR functionality support

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -226,6 +226,11 @@ func (p *Parser) parseTerm(c *sitter.Node) term.Term {
 			p.parseTerm(c.Child(0)),
 			p.parseTerm(c.Child(2)),
 		})
+	case "xor_term":
+		return term.NewFunction(term.XorFunctionName, []term.Term{
+			p.parseTerm(c.ChildByFieldName("left")),
+			p.parseTerm(c.ChildByFieldName("right")),
+		})
 	default:
 		traverse(c, 0)
 		panic(fmt.Sprintf("unhandled term type: %s (%s)", c.Type(), c.Content(p.src)))

--- a/term/term.go
+++ b/term/term.go
@@ -46,6 +46,7 @@ const (
 	AndFunctionName   = "and"
 	OrFunctionName    = "or"
 	AddFunctionName   = "add"
+	XorFunctionName   = "xor"
 	BinaryArity       = 2
 	TernaryArity      = 3
 
@@ -59,6 +60,7 @@ var ReservedNames = data.NewSet[string](
 	AddFunctionName,
 	AndFunctionName,
 	OrFunctionName,
+	XorFunctionName,
 	string(FormatIntType),
 	string(FormatStringType),
 	string(FormatByteType))
@@ -895,7 +897,7 @@ func Evaluate(t Term) (Term, error) {
 	switch f.Name {
 	case CatFunctionName:
 		return handleCatFunction(f, newArgs, modified)
-	case AddFunctionName, AndFunctionName, OrFunctionName:
+	case AddFunctionName, AndFunctionName, OrFunctionName, XorFunctionName:
 		return handleArithmeticFunction(f, newArgs, modified)
 	case SliceFunctionName:
 		return handleSliceFunction(f, newArgs, modified)
@@ -999,6 +1001,8 @@ func handleArithmeticFunction(f *Function, args []Term, modified bool) (Term, er
 		result = left & right
 	case OrFunctionName:
 		result = left | right
+	case XorFunctionName:
+		result = left ^ right
 	}
 
 	// Result type is the same as the type of the first argument.

--- a/term/term_test.go
+++ b/term/term_test.go
@@ -296,6 +296,36 @@ func TestEvaluate(t *testing.T) {
 			false,
 		},
 		{
+			// evaluate(xor(243, 15)) | 252
+			term.NewFunction(term.XorFunctionName, []term.Term{
+				term.NewConstant[int](243),
+				term.NewConstant[int](15),
+			}),
+			term.NewConstant[int](252),
+			false,
+		},
+		{
+			// evaluate(xor('0xf3', 15)) | 0xfc
+			term.NewFunction(term.XorFunctionName, []term.Term{
+				term.NewConstant[[]byte]([]byte{0xf3}),
+				term.NewConstant[int](15),
+			}),
+			term.NewConstant[[]byte]([]byte{0xfc}),
+			false,
+		},
+		{
+			// evaluate(xor(xor('0xaa', '0x55'), '0xff')) | 0x00
+			term.NewFunction(term.XorFunctionName, []term.Term{
+				term.NewFunction(term.XorFunctionName, []term.Term{
+					term.NewConstant[[]byte]([]byte{0xaa}),
+					term.NewConstant[int](0x55),
+				}),
+				term.NewConstant[int](0xff),
+			}),
+			term.NewConstant[[]byte]([]byte{0x00}),
+			false,
+		},
+		{
 			// ekI = cat( byte(and('0x3f', '248'), '1'), byte('0xbfe12c4f8e0d10f3f361ae081089edbef9a6953e8846269b1218efaf62a1', '30), byte(or(and('0x30', '127'), '64'), '1'))
 			term.NewFunction(term.CatFunctionName, []term.Term{
 				term.NewFunction(string(term.FormatByteType), []term.Term{


### PR DESCRIPTION
**Summary**
This pull request adds support for the XOR logical operation to specmon's term evaluation system.

**Changes Made**

- term/term.go: Implemented XOR operation logic for term evaluation
- term/term_test.go: Added test cases to verify XOR functionality
- parser/parser.go: Extended parser to recognize and handle XOR operator syntax

