### PR TITLE
fix(docs): Add pnpm workspace packages entry

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - "."
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
Add "." to packages so pnpm 10 treats docs as a valid workspace and `pnpm install --frozen-lockfile` succeeds in Cloudflare builds.