### PR TITLE
refactor(parser): Migrate to official tree-sitter Go bindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,25 @@
 module github.com/specmon/specmon
 
-go 1.21.4
+go 1.25
 
 require (
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/fatih/color v1.16.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/smacker/go-tree-sitter v0.0.0-20231219031718-233c2f923ac7
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.7.4
+	github.com/tree-sitter/go-tree-sitter v0.25.0
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 )
+
+replace github.com/tree-sitter/go-tree-sitter => github.com/specmon/go-tree-sitter v0.0.0-20260115142046-b5a8316e1814
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-pointer v0.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,13 +13,15 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
+github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smacker/go-tree-sitter v0.0.0-20231219031718-233c2f923ac7 h1:PeBjmUlvTGvg6SyM4u7pyk8YCmdbgdFcGrwf7dRBV80=
-github.com/smacker/go-tree-sitter v0.0.0-20231219031718-233c2f923ac7/go.mod h1:q99oHDsbP0xRwmn7Vmob8gbSMNyvJ83OauXPSuHQuKE=
+github.com/specmon/go-tree-sitter v0.0.0-20260115142046-b5a8316e1814 h1:HLQONWL4E/R1HU2HGCGrUUCnQbl1vrNKldc7T6aAHW0=
+github.com/specmon/go-tree-sitter v0.0.0-20260115142046-b5a8316e1814/go.mod h1:J37zXPOSxJJs4hx7cuVnzbHUwu7pQGA/WPZooIo9xDc=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -28,7 +28,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 
 	spthy "github.com/specmon/specmon/parser/tree-sitter-spthy"
 	"github.com/specmon/specmon/rule"
@@ -102,18 +102,19 @@ func (e *ParseError) Unwrap() error {
 func childrenByFieldName(node *sitter.Node, fieldName string) []*sitter.Node {
 	var results []*sitter.Node
 
-	cursor := sitter.NewTreeCursor(node)
-	cursor.GoToFirstChild()
-	done := false
-	for !done {
-		for cursor.CurrentFieldName() != fieldName {
-			if !cursor.GoToNextSibling() {
-				return results
-			}
+	cursor := node.Walk()
+	defer cursor.Close()
+
+	if !cursor.GotoFirstChild() {
+		return results
+	}
+
+	for {
+		if cursor.FieldName() == fieldName {
+			results = append(results, cursor.Node())
 		}
-		results = append(results, cursor.CurrentNode())
-		if !cursor.GoToNextSibling() {
-			done = true
+		if !cursor.GotoNextSibling() {
+			break
 		}
 	}
 
@@ -122,8 +123,14 @@ func childrenByFieldName(node *sitter.Node, fieldName string) []*sitter.Node {
 
 func getCaptureMap(q *sitter.Query, m *sitter.QueryMatch) map[string]*sitter.Node {
 	captures := make(map[string]*sitter.Node)
+	captureNames := q.CaptureNames()
 	for _, c := range m.Captures {
-		captures[q.CaptureNameForId(c.Index)] = c.Node
+		index := int(c.Index)
+		if index >= len(captureNames) {
+			continue
+		}
+		node := c.Node
+		captures[captureNames[index]] = &node
 	}
 
 	return captures
@@ -136,28 +143,31 @@ func (p *Parser) errorNodeToError(node *sitter.Node) error {
 
 	// TODO: node.HasError also returns true if a subnode is missing or extra.
 	// In this case, the error pattern failes to match.
-	query, err := sitter.NewQuery([]byte(errorPattern), p.lang)
+	query, err := sitter.NewQuery(p.lang, errorPattern)
 	if err != nil {
 		return &ParseError{p, err}
 	}
+	defer query.Close()
 
 	queryCursor := sitter.NewQueryCursor()
-	queryCursor.Exec(query, node)
+	defer queryCursor.Close()
 
-	m, ok := queryCursor.NextMatch()
-	if !ok {
+	matches := queryCursor.Matches(query, node, p.src)
+	m := matches.Next()
+	if m == nil {
 		return &ParseError{p, errors.New("cannot match error pattern")}
 	}
 
 	captures := getCaptureMap(query, m)
 	if errorNode, ok := captures["error"]; ok {
-		errorLine := int(errorNode.StartPoint().Row + 1)
-		errorColumn := int(errorNode.StartPoint().Column + 1)
+		start := errorNode.StartPosition()
+		errorLine := start.Row + 1
+		errorColumn := start.Column + 1
 
 		srcLines := strings.Split(string(p.src), "\n")
 
-		beforeContextLine := max(0, errorLine-errorContextBeforeOffset-1)
-		afterContextLine := min(len(srcLines), errorLine+errorContextAfterOffset)
+		beforeContextLine := max(0, int(errorLine)-errorContextBeforeOffset-1)         //nolint:gosec
+		afterContextLine := min(len(srcLines), int(errorLine)+errorContextAfterOffset) //nolint:gosec
 
 		errorContext := srcLines[beforeContextLine:afterContextLine]
 
@@ -170,12 +180,12 @@ func (p *Parser) errorNodeToError(node *sitter.Node) error {
 }
 
 func (p *Parser) parseTerm(c *sitter.Node) term.Term {
-	switch c.Type() {
+	switch c.Kind() {
 	case "msg_var_or_nullary_fun", "pub_var", "fresh_var":
 		ident := c.ChildByFieldName("variable_identifier")
 		if ident != nil {
-			v := ident.Content(p.src)
-			if c.Type() == "pub_var" {
+			v := ident.Utf8Text(p.src)
+			if c.Kind() == "pub_var" {
 				v = term.PublicPrefix + v
 			}
 
@@ -185,20 +195,20 @@ func (p *Parser) parseTerm(c *sitter.Node) term.Term {
 		// The parser doesn't distinguish between a constant number literal
 		// and a variable. Hence, we need to try to parse the number as an interger.
 		ident := c.ChildByFieldName("variable_identifier")
-		if i, err := strconv.Atoi(ident.Content(p.src)); err == nil {
+		if i, err := strconv.Atoi(ident.Utf8Text(p.src)); err == nil {
 			return term.NewConstant[int](i)
 		}
 
-		return term.NewVariable(ident.Content(p.src))
+		return term.NewVariable(ident.Utf8Text(p.src))
 	case "pub_name":
 		return p.parsePubName(c)
 	case "nary_app", "nullary_fun":
 		ident := c.ChildByFieldName("function_identifier")
 		args := []term.Term{}
 		if ident != nil {
-			for i := uint32(0); i < c.ChildCount(); i++ {
-				child := c.Child(int(i))
-				if child.Type() == "arguments" {
+			for i := uint(0); i < c.ChildCount(); i++ {
+				child := c.Child(i)
+				if child.Kind() == "arguments" {
 					arguments := childrenByFieldName(child, "argument")
 					for _, arg := range arguments {
 						args = append(args, p.parseTerm(arg))
@@ -206,7 +216,7 @@ func (p *Parser) parseTerm(c *sitter.Node) term.Term {
 				}
 			}
 
-			return term.NewFunction(ident.Content(p.src), args)
+			return term.NewFunction(ident.Utf8Text(p.src), args)
 		}
 	case "tuple_term":
 		termNodes := childrenByFieldName(c, "term")
@@ -228,7 +238,7 @@ func (p *Parser) parseTerm(c *sitter.Node) term.Term {
 		})
 	default:
 		traverse(c, 0)
-		panic(fmt.Sprintf("unhandled term type: %s (%s)", c.Type(), c.Content(p.src)))
+		panic(fmt.Sprintf("unhandled term type: %s (%s)", c.Kind(), c.Utf8Text(p.src)))
 	}
 
 	return nil
@@ -237,18 +247,14 @@ func (p *Parser) parseTerm(c *sitter.Node) term.Term {
 func (p *Parser) parseFacts(node *sitter.Node, factQuery *sitter.Query, factQueryCursor *sitter.QueryCursor) []*rule.Fact {
 	var facts []*rule.Fact
 
-	factQueryCursor.Exec(factQuery, node)
-	for {
-		m, ok := factQueryCursor.NextMatch()
-		if !ok {
-			break
-		}
+	matches := factQueryCursor.Matches(factQuery, node, p.src)
+	for m := matches.Next(); m != nil; m = matches.Next() {
 		captures := getCaptureMap(factQuery, m)
 
 		args := []term.Term{}
 		if captures["fact.arguments"] != nil {
-			for i := uint32(0); i < captures["fact.arguments"].ChildCount(); i++ {
-				c := captures["fact.arguments"].Child(int(i))
+			for i := uint(0); i < captures["fact.arguments"].ChildCount(); i++ {
+				c := captures["fact.arguments"].Child(i)
 				if c.IsNamed() {
 					args = append(args, p.parseTerm(c))
 				}
@@ -256,14 +262,14 @@ func (p *Parser) parseFacts(node *sitter.Node, factQuery *sitter.Query, factQuer
 		}
 
 		var factType rule.FactType
-		switch captures["fact"].Type() {
+		switch captures["fact"].Kind() {
 		case "linear_fact":
 			factType = rule.LinearFact
 		case "persistent_fact":
 			factType = rule.PersistentFact
 		}
 
-		fact := rule.NewFact(captures["fact.name"].Content(p.src), args, factType)
+		fact := rule.NewFact(captures["fact.name"].Utf8Text(p.src), args, factType)
 
 		facts = append(facts, fact)
 	}
@@ -299,11 +305,22 @@ func parseRules(ctx context.Context, filename string, src []byte) ([]*rule.Rule,
 	p := NewParser(filename, src, spthy.GetLanguage())
 
 	sitterParser := sitter.NewParser()
-	sitterParser.SetLanguage(p.lang)
-
-	tree, err := sitterParser.ParseCtx(ctx, nil, src)
-	if err != nil {
+	defer sitterParser.Close()
+	if err := sitterParser.SetLanguage(p.lang); err != nil {
 		return nil, &ParseError{p, err}
+	}
+
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, &ParseError{p, ctx.Err()}
+		default:
+		}
+	}
+
+	tree := sitterParser.Parse(src, nil)
+	if tree == nil {
+		return nil, &ParseError{p, errors.New("failed to parse source")}
 	}
 
 	rootNode := tree.RootNode()
@@ -312,51 +329,52 @@ func parseRules(ctx context.Context, filename string, src []byte) ([]*rule.Rule,
 		return nil, &ParseError{p, err}
 	}
 
-	ruleQuery, err := sitter.NewQuery([]byte(rulePattern), spthy.GetLanguage())
+	ruleQuery, err := sitter.NewQuery(spthy.GetLanguage(), rulePattern)
 	if err != nil {
 		return nil, &ParseError{p, err}
 	}
+	defer ruleQuery.Close()
 
-	factQuery, err := sitter.NewQuery([]byte(factPattern), spthy.GetLanguage())
+	factQuery, err := sitter.NewQuery(spthy.GetLanguage(), factPattern)
 	if err != nil {
 		return nil, &ParseError{p, err}
 	}
+	defer factQuery.Close()
 
 	ruleQueryCursor := sitter.NewQueryCursor()
-	ruleQueryCursor.Exec(ruleQuery, rootNode)
+	defer ruleQueryCursor.Close()
 
 	factQueryCursor := sitter.NewQueryCursor()
+	defer factQueryCursor.Close()
 
 	// formats := filterFormatMacros(p.parseMacros(rootNode))
 	formats := p.parseMacros(rootNode)
 
 	var rules []*rule.Rule
-	for {
+	ruleMatches := ruleQueryCursor.Matches(ruleQuery, rootNode, src)
+	for m := ruleMatches.Next(); m != nil; m = ruleMatches.Next() {
 		b := term.NewBinding()
 
-		m, ok := ruleQueryCursor.NextMatch()
-		if !ok {
-			break
-		}
+		captureMap := getCaptureMap(ruleQuery, m)
 
 		r := rule.NewRule()
-		for _, c := range m.Captures {
-			ruleCaptureName := ruleQuery.CaptureNameForId(c.Index)
-
-			switch ruleCaptureName {
-			case "rule.name":
-				r.Name = c.Node.Content(src)
-			case "rule.attrs":
-				r.Attrs = p.parseRuleAttributes(c.Node)
-			case "rule.let_block":
-				b = p.parseLetBlock(c.Node)
-			case "rule.LHS":
-				r.LHS = p.parseFacts(c.Node, factQuery, factQueryCursor)
-			case "rule.Act":
-				r.Act = p.parseFacts(c.Node, factQuery, factQueryCursor)
-			case "rule.RHS":
-				r.RHS = p.parseFacts(c.Node, factQuery, factQueryCursor)
-			}
+		if node := captureMap["rule.name"]; node != nil {
+			r.Name = node.Utf8Text(src)
+		}
+		if node := captureMap["rule.attrs"]; node != nil {
+			r.Attrs = p.parseRuleAttributes(node)
+		}
+		if node := captureMap["rule.let_block"]; node != nil {
+			b = p.parseLetBlock(node)
+		}
+		if node := captureMap["rule.LHS"]; node != nil {
+			r.LHS = p.parseFacts(node, factQuery, factQueryCursor)
+		}
+		if node := captureMap["rule.Act"]; node != nil {
+			r.Act = p.parseFacts(node, factQuery, factQueryCursor)
+		}
+		if node := captureMap["rule.RHS"]; node != nil {
+			r.RHS = p.parseFacts(node, factQuery, factQueryCursor)
 		}
 
 		// FIX: Need to check how to compute the fix point of formats and expend them
@@ -370,21 +388,38 @@ func parseRules(ctx context.Context, filename string, src []byte) ([]*rule.Rule,
 // Parse parses the given source code and returns a tree-sitter tree.
 func Parse(ctx context.Context, source []byte) (*sitter.Tree, error) {
 	parser := sitter.NewParser()
+	defer parser.Close()
 	lang := spthy.GetLanguage()
-	parser.SetLanguage(lang)
-	return parser.ParseCtx(ctx, nil, source)
+	if err := parser.SetLanguage(lang); err != nil {
+		return nil, err
+	}
+
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+
+	tree := parser.Parse(source, nil)
+	if tree == nil {
+		return nil, errors.New("failed to parse source")
+	}
+
+	return tree, nil
 }
 
 // parseRuleAttributes parses the attributes of a rule node and returns a map of attribute key-value pairs.
 func (p *Parser) parseRuleAttributes(node *sitter.Node) map[string]rule.Attribute {
 	attrs := make(map[string]rule.Attribute)
 
-	for i := uint32(0); i < node.ChildCount(); i++ {
-		ruleAttr := node.Child(int(i))
-		if ruleAttr.Type() != "rule_attr" {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		ruleAttr := node.Child(i)
+		if ruleAttr.Kind() != "rule_attr" {
 			continue
 		}
-		attrKey := strings.TrimSuffix(ruleAttr.Child(0).Type(), "=")
+		attrKey := strings.TrimSuffix(ruleAttr.Child(0).Kind(), "=")
 
 		switch attrKey {
 		case "hint", "trigger":
@@ -397,7 +432,7 @@ func (p *Parser) parseRuleAttributes(node *sitter.Node) map[string]rule.Attribut
 		default:
 			var attrValue string
 			if ruleAttr.ChildCount() > 2 {
-				attrValue = ruleAttr.Child(2).Content(p.src)
+				attrValue = ruleAttr.Child(2).Utf8Text(p.src)
 			}
 			attrs[attrKey] = rule.StringAttribute{Value: attrValue}
 		}
@@ -409,9 +444,9 @@ func (p *Parser) parseRuleAttributes(node *sitter.Node) map[string]rule.Attribut
 func (p *Parser) parseLetBlock(node *sitter.Node) *term.Binding {
 	b := term.NewBinding()
 
-	for i := uint32(0); i < node.ChildCount(); i++ {
-		letItem := node.Child(int(i))
-		if letItem.Type() != "rule_let_term" {
+	for i := uint(0); i < node.ChildCount(); i++ {
+		letItem := node.Child(i)
+		if letItem.Kind() != "rule_let_term" {
 			continue
 		}
 
@@ -427,19 +462,18 @@ func (p *Parser) parseLetBlock(node *sitter.Node) *term.Binding {
 func (p *Parser) parseMacros(n *sitter.Node) *term.Binding {
 	b := term.NewBinding()
 
-	query, err := sitter.NewQuery([]byte(macroPattern), p.lang)
+	query, err := sitter.NewQuery(p.lang, macroPattern)
 	if err != nil {
 		return b
 	}
+	defer query.Close()
 
 	cursor := sitter.NewQueryCursor()
-	cursor.Exec(query, n)
+	defer cursor.Close()
 
-	for {
-		m, ok := cursor.NextMatch()
-		if !ok {
-			break
-		}
+	matches := cursor.Matches(query, n, p.src)
+
+	for m := matches.Next(); m != nil; m = matches.Next() {
 
 		captureMap := getCaptureMap(query, m)
 
@@ -462,7 +496,7 @@ func (p *Parser) parseMacros(n *sitter.Node) *term.Binding {
 // parsePubName parses a pub_name node and returns a constant.
 func (p *Parser) parsePubName(n *sitter.Node) term.Term {
 	// FIXME: pub_name wrapped in single quotes.
-	name := strings.Trim(n.Content(p.src), "'")
+	name := strings.Trim(n.Utf8Text(p.src), "'")
 
 	if i, err := strconv.Atoi(name); err == nil {
 		return term.NewConstant[int](i)
@@ -483,11 +517,11 @@ func (p *Parser) parsePubName(n *sitter.Node) term.Term {
 // traverse a node and print its type and content.
 func traverse(node *sitter.Node, depth int) {
 	// Print information about the current node
-	fmt.Printf("%*sType: %s, Start: %d, End: %d, Node: %v\n", depth*2, "", node.Type(), node.StartByte(), node.EndByte(), node)
+	fmt.Printf("%*sType: %s, Start: %d, End: %d, Node: %v\n", depth*2, "", node.Kind(), node.StartByte(), node.EndByte(), node)
 
 	// Recursively traverse child nodes
-	for i := uint32(0); i < node.ChildCount(); i++ {
-		child := node.Child(int(i))
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
 		traverse(child, depth+1)
 	}
 }

--- a/parser/preprocessor.go
+++ b/parser/preprocessor.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"bytes"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 // Preprocessor holds the state for the preprocessing pass.
@@ -33,7 +33,7 @@ func (p *Preprocessor) Run(root *sitter.Node) []byte {
 
 // walk traverses the AST and writes the processed source to the buffer.
 func (p *Preprocessor) walk(node *sitter.Node, out *bytes.Buffer) {
-	nodeType := node.Type()
+	nodeType := node.Kind()
 
 	if nodeType == "preprocessor" {
 		// The preprocessor node itself doesn't have content, but it has a child
@@ -52,7 +52,7 @@ func (p *Preprocessor) walk(node *sitter.Node, out *bytes.Buffer) {
 		// any whitespace between children by tracking byte positions
 		lastEndByte := node.StartByte()
 
-		for i := 0; i < int(node.ChildCount()); i++ {
+		for i := uint(0); i < node.ChildCount(); i++ {
 			child := node.Child(i)
 
 			// Copy any whitespace/content between the last child and this one
@@ -74,7 +74,7 @@ func (p *Preprocessor) walk(node *sitter.Node, out *bytes.Buffer) {
 
 // handlePreprocessor evaluates a preprocessor directive.
 func (p *Preprocessor) handlePreprocessor(node *sitter.Node, out *bytes.Buffer) {
-	if node.Type() == "ifdef" {
+	if node.Kind() == "ifdef" {
 		// Use field-based access instead of child indices
 		conditionNode := node.ChildByFieldName("condition")
 
@@ -82,7 +82,7 @@ func (p *Preprocessor) handlePreprocessor(node *sitter.Node, out *bytes.Buffer) 
 			return // No condition found
 		}
 
-		condition := conditionNode.Content(p.source)
+		condition := conditionNode.Utf8Text(p.source)
 		if p.defines[condition] {
 			// Condition is true, process all 'consequence' nodes
 			consequenceNodes := childrenByFieldName(node, "consequence")

--- a/parser/tree-sitter-spthy/binding.go
+++ b/parser/tree-sitter-spthy/binding.go
@@ -26,7 +26,7 @@ import "C"
 import (
 	"unsafe"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 func GetLanguage() *sitter.Language {


### PR DESCRIPTION
Replace smacker/go-tree-sitter with tree-sitter/go-tree-sitter, the official Go bindings maintained by the tree-sitter project. Use a replace directive pointing to specmon/go-tree-sitter fork to avoid pulling in unnecessary language bindings from the upstream test suite.

Key API changes:
- Content() → Utf8Text()
- Type() → Kind()
- NewTreeCursor() → node.Walk()
- Query constructor argument order swapped
- Match iteration via Matches().Next() instead of NextMatch()
- Added proper resource cleanup with Close() and defer
- Child iteration index type changed from uint32 to uint