### PR TITLE
ci(release): Treat breaking changes as minor bumps below v1.0.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,7 +88,7 @@ SpecMon uses [Release Please](https://github.com/googleapis/release-please) and
   Release Please determines the next version automatically:
   - `fix:` → patch (0.1.0 → 0.1.1)
   - `feat:` → minor (0.1.0 → 0.2.0)
-  - `feat!:` or `BREAKING CHANGE:` footer → major (0.1.0 → 1.0.0)
+  - `feat!:` or `BREAKING CHANGE:` → minor while version < 1.0.0; major once ≥ 1.0.0
 - Review the Release PR's `CHANGELOG.md` diff before merging.
 - After the release is published, merge `develop → main` to update the stable branch.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
-      "tag-name": "v${version}"
+      "tag-name": "v${version}",
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Add bump-minor-pre-major to release-please-config.json so that feat and BREAKING CHANGE commits bump the minor version (0.1.0 → 0.2.0) rather than triggering a major release while the project is still in the 0.x.y development phase.

Update CONTRIBUTING.md to document the pre-1.0.0 bump behaviour.