### PR TITLE
ci(release): Fix PR title pattern and add workflow_dispatch for GoReleaser

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,11 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag to build and release (e.g. v0.2.0)'
+        required: true
 
 permissions:
   contents: write
@@ -29,14 +34,14 @@ jobs:
 
   goreleaser:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: macos-14
     steps:
       - name: Check out code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ github.event.inputs.tag_name || needs.release-please.outputs.tag_name }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "target-branch": "develop",
+  "pull-request-title-pattern": "chore${scope}${component}: Release ${version}",
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Add pull-request-title-pattern to release-please-config.json so Release Please can parse its own PR titles when creating the tag and release.

Add workflow_dispatch trigger to the release-please workflow so GoReleaser can be run manually against a specific tag for release recovery.

Fix release_created condition to use explicit == 'true' comparison.