### PR TITLE
Call third-party tool in path like git

### DIFF
--- a/cmd/dispatch.go
+++ b/cmd/dispatch.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -32,42 +33,16 @@ func FindFirstNonFlag(argv []string) (int, string) {
 	return -1, ""
 }
 
-// DispatchExternal inspects argv for a candidate subcommand (first non-flag token).
-// If the token is not a built-in subcommand of the provided cobra root command,
-// DispatchExternal will look for an executable named "specmon-<candidate>" on PATH.
-// If such an executable is found it attempts to replace the current process with it
-// (syscall.Exec). If exec fails it falls back to spawning the child process,
-// wiring stdin/stdout/stderr, forwarding SIGINT/SIGTERM and propagating the child's
-// exit code. DispatchExternal returns true if an external program was found and
-// dispatched (the function may not return if exec replacement succeeds or when the
-// child process exits), and false if no external program was applicable/found.
-func DispatchExternal(root *cobra.Command, argv []string) bool {
-	idx, candidate := FindFirstNonFlag(argv)
-	if candidate == "" {
-		return false
+// findExecutableOnPath attempts to locate an executable named exeName on PATH.
+// On Windows it defers to exec.LookPath (respects PATHEXT). On POSIX it performs
+// a manual scan and returns an absolute path when found.
+func findExecutableOnPath(exeName string) (string, error) {
+	if runtime.GOOS == "windows" {
+		// exec.LookPath handles PATHEXT on Windows.
+		return exec.LookPath(exeName)
 	}
 
-	// If candidate matches a built-in subcommand or alias, don't dispatch externally.
-	for _, c := range root.Commands() {
-		if c == nil {
-			continue
-		}
-		if c.Name() == candidate {
-			return false
-		}
-		for _, a := range c.Aliases {
-			if a == candidate {
-				return false
-			}
-		}
-	}
-	if candidate == "help" {
-		return false
-	}
-
-	// Look for an executable named "<Name>-<candidate>" on PATH.
-	exeName := fmt.Sprintf("%s-%s", Name, candidate)
-	var foundPath string
+	// POSIX: manual scan of PATH entries and require execute bit.
 	if p := os.Getenv("PATH"); p != "" {
 		for _, dir := range strings.Split(p, string(os.PathListSeparator)) {
 			if dir == "" {
@@ -80,45 +55,27 @@ func DispatchExternal(root *cobra.Command, argv []string) bool {
 			}
 			if info.Mode().IsRegular() && info.Mode().Perm()&0111 != 0 {
 				if abs, err := filepath.Abs(candidatePath); err == nil {
-					foundPath = abs
-				} else {
-					foundPath = candidatePath
+					return abs, nil
 				}
-				break
+				return candidatePath, nil
 			}
 		}
 	}
-	if foundPath == "" {
-		return false
-	}
+	return "", fmt.Errorf("not found")
+}
 
-	// Build argv for the external process: argv0 should be "specmon-<candidate>" and
-	// the arguments are everything following the candidate token.
-	childArgs := []string{}
-	if idx >= 0 && idx+1 < len(argv) {
-		childArgs = argv[idx+1:]
-	}
-	argv0 := fmt.Sprintf("%s-%s", Name, candidate)
-	argvList := append([]string{argv0}, childArgs...)
-
-	// Try to replace current process (POSIX syscall.Exec).
-	if err := syscall.Exec(foundPath, argvList, os.Environ()); err == nil {
-		// On success this does not return.
-		return true
-	} else {
-		// Exec failed: fall back to spawn-and-wait with a helpful message.
-		fmt.Fprintf(os.Stderr, "exec failed (%v), falling back to spawn-and-wait\n", err)
-	}
-
-	// Spawn fallback: start child, wire stdio, forward signals, wait and propagate exit code.
-	child := exec.Command(foundPath, childArgs...)
+// spawnAndWait runs the command at path with args, wires stdio, forwards signals,
+// waits for it to finish, and exits the current process with the child's exit code.
+// It does not return.
+func spawnAndWait(path string, args []string) {
+	child := exec.Command(path, args...)
 	child.Stdin = os.Stdin
 	child.Stdout = os.Stdout
 	child.Stderr = os.Stderr
 	child.Env = os.Environ()
 
 	if err := child.Start(); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start external command %s: %v\n", foundPath, err)
+		fmt.Fprintf(os.Stderr, "failed to start external command %s: %v\n", path, err)
 		// Conventional exit code for command not found / cannot execute.
 		os.Exit(127)
 	}
@@ -142,7 +99,91 @@ func DispatchExternal(root *cobra.Command, argv []string) bool {
 	if child.ProcessState != nil {
 		os.Exit(child.ProcessState.ExitCode())
 	}
-	// Shouldn't reach here, but exit success just in case.
 	os.Exit(0)
+}
+
+// DispatchExternal inspects argv for a candidate subcommand (first non-flag token).
+// If the token is not a built-in subcommand of the provided cobra root command,
+// DispatchExternal will look for an executable named "<Name>-<candidate>" on PATH.
+//
+// On POSIX systems it will prefer to replace the current process using syscall.Exec
+// (git-like). On Windows it will spawn the external process and wait, wiring stdio
+// and propagating the exit code. In both cases the function returns true if an
+// external program was found and dispatched; otherwise it returns false.
+func DispatchExternal(root *cobra.Command, argv []string) bool {
+	// Locate candidate token
+	idx, candidate := FindFirstNonFlag(argv)
+	if candidate == "" {
+		return false
+	}
+
+	// If candidate matches a built-in subcommand or alias, don't dispatch externally.
+	for _, c := range root.Commands() {
+		if c == nil {
+			continue
+		}
+		if c.Name() == candidate {
+			return false
+		}
+		for _, a := range c.Aliases {
+			if a == candidate {
+				return false
+			}
+		}
+	}
+	if candidate == "help" {
+		return false
+	}
+
+	// External program name
+	exeName := fmt.Sprintf("%s-%s", Name, candidate)
+
+	// Try to find the external executable
+	path, err := findExecutableOnPath(exeName)
+	if err != nil {
+		return false
+	}
+
+	// Build argv for external: argv0 should be "<Name>-<candidate>", args are the remainder
+	childArgs := []string{}
+	if idx >= 0 && idx+1 < len(argv) {
+		childArgs = argv[idx+1:]
+	}
+	argv0 := fmt.Sprintf("%s-%s", Name, candidate)
+	argvList := append([]string{argv0}, childArgs...)
+
+	// Windows: spawn-and-wait (exec replacement unavailable)
+	if runtime.GOOS == "windows" {
+		// Use exec.Command and Run to wait and capture exit code
+		child := exec.Command(path, childArgs...)
+		child.Stdin = os.Stdin
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		child.Env = os.Environ()
+
+		if err := child.Run(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				os.Exit(exitErr.ExitCode())
+			}
+			fmt.Fprintf(os.Stderr, "failed to execute external command %s: %v\n", path, err)
+			os.Exit(127)
+		}
+		if child.ProcessState != nil {
+			os.Exit(child.ProcessState.ExitCode())
+		}
+		os.Exit(0)
+		return true
+	}
+
+	// POSIX: try syscall.Exec first to replace current process (git-like)
+	if err := syscall.Exec(path, argvList, os.Environ()); err == nil {
+		// successful exec does not return
+		return true
+	}
+
+	// Exec failed: fall back to spawn-and-wait.
+	fmt.Fprintf(os.Stderr, "exec failed (%v), falling back to spawn-and-wait\n", err)
+	spawnAndWait(path, childArgs)
+	// spawnAndWait does not return
 	return true
 }

--- a/cmd/dispatch.go
+++ b/cmd/dispatch.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+// FindFirstNonFlag returns the index and value of the first non-flag token in argv.
+// It treats a standalone "--" as end-of-flags and returns the following token if present.
+// The returned index is the index in argv of that token (or -1 if none).
+func FindFirstNonFlag(argv []string) (int, string) {
+	for i := 1; i < len(argv); i++ {
+		a := argv[i]
+		if a == "--" {
+			if i+1 < len(argv) {
+				return i + 1, argv[i+1]
+			}
+			return -1, ""
+		}
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		return i, a
+	}
+	return -1, ""
+}
+
+// DispatchExternal inspects argv for a candidate subcommand (first non-flag token).
+// If the token is not a built-in subcommand of the provided cobra root command,
+// DispatchExternal will look for an executable named "specmon-<candidate>" on PATH.
+// If such an executable is found it attempts to replace the current process with it
+// (syscall.Exec). If exec fails it falls back to spawning the child process,
+// wiring stdin/stdout/stderr, forwarding SIGINT/SIGTERM and propagating the child's
+// exit code. DispatchExternal returns true if an external program was found and
+// dispatched (the function may not return if exec replacement succeeds or when the
+// child process exits), and false if no external program was applicable/found.
+func DispatchExternal(root *cobra.Command, argv []string) bool {
+	idx, candidate := FindFirstNonFlag(argv)
+	if candidate == "" {
+		return false
+	}
+
+	// If candidate matches a built-in subcommand or alias, don't dispatch externally.
+	for _, c := range root.Commands() {
+		if c == nil {
+			continue
+		}
+		if c.Name() == candidate {
+			return false
+		}
+		for _, a := range c.Aliases {
+			if a == candidate {
+				return false
+			}
+		}
+	}
+	if candidate == "help" {
+		return false
+	}
+
+	// Look for an executable named "<Name>-<candidate>" on PATH.
+	exeName := fmt.Sprintf("%s-%s", Name, candidate)
+	var foundPath string
+	if p := os.Getenv("PATH"); p != "" {
+		for _, dir := range strings.Split(p, string(os.PathListSeparator)) {
+			if dir == "" {
+				dir = "."
+			}
+			candidatePath := filepath.Join(dir, exeName)
+			info, err := os.Stat(candidatePath)
+			if err != nil {
+				continue
+			}
+			if info.Mode().IsRegular() && info.Mode().Perm()&0111 != 0 {
+				if abs, err := filepath.Abs(candidatePath); err == nil {
+					foundPath = abs
+				} else {
+					foundPath = candidatePath
+				}
+				break
+			}
+		}
+	}
+	if foundPath == "" {
+		return false
+	}
+
+	// Build argv for the external process: argv0 should be "specmon-<candidate>" and
+	// the arguments are everything following the candidate token.
+	childArgs := []string{}
+	if idx >= 0 && idx+1 < len(argv) {
+		childArgs = argv[idx+1:]
+	}
+	argv0 := fmt.Sprintf("%s-%s", Name, candidate)
+	argvList := append([]string{argv0}, childArgs...)
+
+	// Try to replace current process (POSIX syscall.Exec).
+	if err := syscall.Exec(foundPath, argvList, os.Environ()); err == nil {
+		// On success this does not return.
+		return true
+	} else {
+		// Exec failed: fall back to spawn-and-wait with a helpful message.
+		fmt.Fprintf(os.Stderr, "exec failed (%v), falling back to spawn-and-wait\n", err)
+	}
+
+	// Spawn fallback: start child, wire stdio, forward signals, wait and propagate exit code.
+	child := exec.Command(foundPath, childArgs...)
+	child.Stdin = os.Stdin
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	child.Env = os.Environ()
+
+	if err := child.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start external command %s: %v\n", foundPath, err)
+		// Conventional exit code for command not found / cannot execute.
+		os.Exit(127)
+	}
+
+	// Forward SIGINT/SIGTERM to the child so interactive commands behave correctly.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		for s := range sigCh {
+			_ = child.Process.Signal(s)
+		}
+	}()
+
+	if err := child.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintf(os.Stderr, "external command failed: %v\n", err)
+		os.Exit(1)
+	}
+	if child.ProcessState != nil {
+		os.Exit(child.ProcessState.ExitCode())
+	}
+	// Shouldn't reach here, but exit success just in case.
+	os.Exit(0)
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -1,21 +1,3 @@
-// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
-// Author: Kevin Morio <kevin.morio@cispa.de>
-//
-// This file is part of SpecMon.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with program. If not, see <https://www.gnu.org/licenses/>.
-
 package main
 
 import (
@@ -25,7 +7,15 @@ import (
 )
 
 func main() {
-	if err := cmd.Root().Execute(); err != nil {
+	rootCmd := cmd.Root()
+
+	// Attempt external dispatch via the cmd package helper.
+	if cmd.DispatchExternal(rootCmd, os.Args) {
+		return
+	}
+
+	// Default: run Cobra normally.
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
To streamline future support for third party tools, this PR makes it so unknown commands `specmon $command` call the binary `specmon-$command` on the path. 

Tested:
```
> PATH=./test-bin:$PATH ./specmon test 
Nice!
```

Should also work in windows (which has no exec to substitute current process) but I cannot test it.