### PR TITLE
feat(rule): Add name generator for consistent term naming

### DIFF
--- a/rule/namegen.go
+++ b/rule/namegen.go
@@ -1,0 +1,398 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package rule
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/specmon/specmon/term"
+)
+
+const (
+	maxGeneratedNameLen = 30
+)
+
+// NameGenerator produces short, readable names for intermediate computation
+// results during rule decomposition. Original variable and constant names
+// are preserved as-is; only function application results are renamed.
+//
+// Generated names are guaranteed not to collide with any variable or function
+// name already present in the rule.
+type NameGenerator struct {
+	funcAbbrev      map[string]string
+	funcSeen        map[string]bool
+	funcOrder       []string
+	termOrder       []string
+	termByKey       map[string]term.Term
+	depthCache      map[string]int
+	structuralCache map[string]string
+	compactTerms    map[string]bool
+	compactNext     map[string]int
+	reserved        map[string]bool // names already in use (user + generated)
+}
+
+func NewNameGenerator(r *Rule) *NameGenerator {
+	g := &NameGenerator{
+		funcAbbrev:      make(map[string]string),
+		funcSeen:        make(map[string]bool),
+		termByKey:       make(map[string]term.Term),
+		depthCache:      make(map[string]int),
+		structuralCache: make(map[string]string),
+		compactTerms:    make(map[string]bool),
+		compactNext:     make(map[string]int),
+		reserved:        make(map[string]bool),
+	}
+
+	g.collectRule(r)
+
+	// Sort for deterministic output regardless of term walk order.
+	slices.Sort(g.funcOrder)
+
+	g.buildFuncAbbrev()
+	g.buildStructuralNames()
+
+	return g
+}
+
+func (g *NameGenerator) NameForTerm(t term.Term) string {
+	switch v := t.(type) {
+	case *term.Variable:
+		return sanitizeName(v.Name)
+	case *term.Constant[int], *term.Constant[string], *term.Constant[[]byte]:
+		return sanitizeName(t.String())
+	case *term.Function:
+		return g.structuralName(v)
+	}
+
+	return sanitizeName(t.String())
+}
+
+func (g *NameGenerator) collectRule(r *Rule) {
+	// Collect function names and terms for abbreviation/ref assignment.
+	walkRuleTerms(r, false, func(t term.Term) {
+		if v, ok := t.(*term.Function); ok {
+			g.ensureFunc(v.Name)
+			g.ensureTerm(v)
+		}
+	})
+
+	// Collect all names already in use to prevent generated names from
+	// colliding with user-defined variables or function names. Include
+	// attributes so that variables in triggers/hints are covered.
+	walkRuleTerms(r, true, func(t term.Term) {
+		switch v := t.(type) {
+		case *term.Variable:
+			g.reserved[sanitizeName(v.Name)] = true
+		case *term.Function:
+			// Include function names — in spthy a bare token is ambiguous
+			// between a variable and a nullary function.
+			g.reserved[v.Name] = true
+		}
+	})
+}
+
+func (g *NameGenerator) ensureFunc(name string) {
+	if g.funcSeen[name] {
+		return
+	}
+	g.funcSeen[name] = true
+	g.funcOrder = append(g.funcOrder, name)
+}
+
+func (g *NameGenerator) ensureTerm(t term.Term) {
+	key := termKey(t)
+	if _, ok := g.termByKey[key]; ok {
+		return
+	}
+	g.termByKey[key] = t
+	g.termOrder = append(g.termOrder, key)
+}
+
+func (g *NameGenerator) buildFuncAbbrev() {
+	used := make(map[string]string)
+	for _, name := range g.funcOrder {
+		g.assignFuncAbbrev(name, used)
+	}
+}
+
+func (g *NameGenerator) funcAbbrevFor(name string) string {
+	if abbrev, ok := g.funcAbbrev[name]; ok {
+		return abbrev
+	}
+
+	used := make(map[string]string, len(g.funcAbbrev))
+	for funcName, abbrev := range g.funcAbbrev {
+		used[abbrev] = funcName
+	}
+
+	return g.assignFuncAbbrev(name, used)
+}
+
+func (g *NameGenerator) assignFuncAbbrev(name string, used map[string]string) string {
+	var abbrev string
+	if len(name) <= 2 {
+		abbrev = name
+		if used[abbrev] != "" {
+			abbrev = shortestUniquePrefix(name, used)
+		}
+	} else {
+		abbrev = shortestUniquePrefix(name, used)
+	}
+
+	g.funcAbbrev[name] = abbrev
+	used[abbrev] = name
+
+	return abbrev
+}
+
+// buildStructuralNames pre-allocates structural names for all function terms in
+// a deterministic order. Processing smaller depths first ensures that inner
+// names are cached before outer names are computed. Within each depth level,
+// terms are sorted by termKey so that suffix allocation via uniqueName is
+// independent of RHS fact order.
+func (g *NameGenerator) buildStructuralNames() {
+	type entry struct {
+		key   string
+		depth int
+	}
+
+	entries := make([]entry, 0, len(g.termOrder))
+	for _, key := range g.termOrder {
+		t := g.termByKey[key]
+		if _, ok := t.(*term.Function); ok {
+			entries = append(entries, entry{key: key, depth: g.termDepth(t)})
+		}
+	}
+
+	// Sort by depth first, then alphabetically by key for determinism.
+	slices.SortFunc(entries, func(a, b entry) int {
+		if c := cmp.Compare(a.depth, b.depth); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.key, b.key)
+	})
+
+	for _, e := range entries {
+		g.structuralName(g.termByKey[e.key].(*term.Function))
+	}
+}
+
+// uniqueName returns candidate if it is not yet reserved, otherwise appends
+// a numeric suffix (_0, _1, ...) until a free name is found. The chosen name
+// is added to the reserved set.
+func (g *NameGenerator) uniqueName(candidate string) string {
+	if !g.reserved[candidate] {
+		g.reserved[candidate] = true
+		return candidate
+	}
+	for i := 0; ; i++ {
+		suffix := fmt.Sprintf("_%d", i)
+		base := candidate
+		if len(base)+len(suffix) > maxGeneratedNameLen {
+			maxBaseLen := max(maxGeneratedNameLen-len(suffix), 1)
+			if len(base) > maxBaseLen {
+				base = strings.TrimRight(base[:maxBaseLen], "_")
+				if base == "" {
+					base = "x"
+				}
+			}
+		}
+		suffixed := base + suffix
+		if !g.reserved[suffixed] {
+			g.reserved[suffixed] = true
+			return suffixed
+		}
+	}
+}
+
+func (g *NameGenerator) termDepth(t term.Term) int {
+	key := termKey(t)
+	if depth, ok := g.depthCache[key]; ok {
+		return depth
+	}
+
+	f, ok := t.(*term.Function)
+	if !ok {
+		g.depthCache[key] = 0
+		return 0
+	}
+
+	maxDepth := 0
+	for _, arg := range f.Args {
+		if arg == nil {
+			continue
+		}
+		maxDepth = max(maxDepth, g.termDepth(arg))
+	}
+	depth := maxDepth + 1
+	g.depthCache[key] = depth
+	return depth
+}
+
+func (g *NameGenerator) structuralName(f *term.Function) string {
+	key := termKey(f)
+	if name, ok := g.structuralCache[key]; ok {
+		return name
+	}
+
+	abbrev := g.funcAbbrevFor(f.Name)
+
+	if len(f.Args) == 0 {
+		name := g.uniqueName(abbrev)
+		g.structuralCache[key] = name
+		return name
+	}
+
+	parts := make([]string, 0, len(f.Args)+1)
+	parts = append(parts, abbrev)
+	needsCompact := false
+	for _, arg := range f.Args {
+		parts = append(parts, g.NameForTerm(arg))
+		if argFunc, ok := arg.(*term.Function); ok && g.compactTerms[termKey(argFunc)] {
+			needsCompact = true
+		}
+	}
+
+	name := strings.Join(parts, "_")
+	if len(name) > maxGeneratedNameLen || needsCompact {
+		name = g.nextCompactName(abbrev)
+		g.compactTerms[key] = true
+	} else {
+		name = g.uniqueName(name)
+	}
+	g.structuralCache[key] = name
+	return name
+}
+
+func (g *NameGenerator) nextCompactName(abbrev string) string {
+	// Cap the abbreviation so that abbrev + digit always fits within the limit.
+	// This handles pathological cases where two long function names share a
+	// long common prefix, producing a lengthy abbreviation.
+	maxAbbrevLen := max(maxGeneratedNameLen-1, 1) // leave room for at least one digit
+	if len(abbrev) > maxAbbrevLen {
+		abbrev = abbrev[:maxAbbrevLen]
+	}
+
+	for {
+		index := g.compactNext[abbrev]
+		g.compactNext[abbrev] = index + 1
+		candidate := fmt.Sprintf("%s%d", abbrev, index)
+		if len(candidate) > maxGeneratedNameLen {
+			// The index itself grew too large for the abbreviation; trim further.
+			trimLen := max(maxGeneratedNameLen-len(fmt.Sprintf("%d", index)), 1)
+			candidate = fmt.Sprintf("%s%d", abbrev[:trimLen], index)
+		}
+		if !g.reserved[candidate] {
+			g.reserved[candidate] = true
+			return candidate
+		}
+	}
+}
+
+// shortestUniquePrefix returns the shortest prefix of name that is not already
+// in used.
+func shortestUniquePrefix(name string, used map[string]string) string {
+	for i := 1; i <= len(name); i++ {
+		candidate := name[:i]
+		if used[candidate] == "" {
+			return candidate
+		}
+	}
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s%d", name, i)
+		if used[candidate] == "" {
+			return candidate
+		}
+	}
+}
+
+// sanitizeName strips Tamarin variable prefixes ($, ~) and keeps only
+// characters valid in identifier names: [a-zA-Z0-9_].
+func sanitizeName(s string) string {
+	// Strip leading $ and ~ prefixes.
+	s = strings.TrimLeft(s, "$~")
+
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			c == '_' {
+			b.WriteByte(c)
+		}
+	}
+	if b.Len() == 0 {
+		return "x"
+	}
+	return b.String()
+}
+
+// termKey returns a string key for a term that is unique across types.
+// Prepending the type prevents cross-type collisions (e.g. a variable
+// named "f(x)" vs a function f(x)).
+func termKey(t term.Term) string {
+	if t == nil {
+		panic("termKey: nil term")
+	}
+	return t.GetType() + ":" + t.String()
+}
+
+func walkRuleTerms(r *Rule, includeAttrs bool, visit func(term.Term)) {
+	if r == nil {
+		return
+	}
+
+	facts := make([]*Fact, 0, len(r.LHS)+len(r.Act)+len(r.RHS))
+	facts = append(facts, r.LHS...)
+	facts = append(facts, r.Act...)
+	facts = append(facts, r.RHS...)
+
+	for _, f := range facts {
+		for _, arg := range f.Args {
+			walkTerm(arg, visit)
+		}
+	}
+
+	if includeAttrs {
+		for _, t := range r.Triggers() {
+			walkTerm(t, visit)
+		}
+		for _, t := range r.Hints() {
+			walkTerm(t, visit)
+		}
+	}
+}
+
+func walkTerm(t term.Term, visit func(term.Term)) {
+	if t == nil {
+		return
+	}
+	visit(t)
+	f, ok := t.(*term.Function)
+	if !ok {
+		return
+	}
+	for _, arg := range f.Args {
+		walkTerm(arg, visit)
+	}
+}

--- a/rule/namegen_test.go
+++ b/rule/namegen_test.go
@@ -1,0 +1,381 @@
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/specmon/specmon/rule"
+	"github.com/specmon/specmon/term"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeRule(rhs []term.Term) *rule.Rule {
+	r := rule.NewRule()
+	r.Name = "R"
+	r.LHS = []*rule.Fact{rule.NewFact("In", []term.Term{term.NewVariable("x")}, rule.LinearFact)}
+	r.RHS = []*rule.Fact{rule.NewFact("Out", rhs, rule.LinearFact)}
+	return r
+}
+
+func makeRuleWithLHS(lhs, rhs []term.Term) *rule.Rule {
+	r := rule.NewRule()
+	r.Name = "R"
+	r.LHS = []*rule.Fact{rule.NewFact("In", lhs, rule.LinearFact)}
+	r.RHS = []*rule.Fact{rule.NewFact("Out", rhs, rule.LinearFact)}
+	return r
+}
+
+func TestNameGenerator_VariablesPreserved(t *testing.T) {
+	t.Parallel()
+	r := makeRule([]term.Term{
+		term.NewFunction("hash", []term.Term{term.NewVariable("m")}),
+	})
+	g := rule.NewNameGenerator(r)
+	got := g.NameForTerm(term.NewVariable("m"))
+	assert.Equal(t, "m", got)
+}
+
+func TestNameGenerator_PublicVarSanitized(t *testing.T) {
+	t.Parallel()
+	r := makeRule([]term.Term{
+		term.NewFunction("hash", []term.Term{term.NewVariable("$secret")}),
+	})
+	g := rule.NewNameGenerator(r)
+	got := g.NameForTerm(term.NewVariable("$secret"))
+	assert.Equal(t, "secret", got)
+}
+
+func TestNameGenerator_FreshVarSanitized(t *testing.T) {
+	t.Parallel()
+	r := makeRule([]term.Term{
+		term.NewFunction("hash", []term.Term{term.NewVariable("~k")}),
+	})
+	g := rule.NewNameGenerator(r)
+	got := g.NameForTerm(term.NewVariable("~k"))
+	assert.Equal(t, "k", got)
+}
+
+func TestNameGenerator_StructuralNames(t *testing.T) {
+	t.Parallel()
+	m := term.NewVariable("m")
+	hashM := term.NewFunction("hash", []term.Term{m})
+	lenHashM := term.NewFunction("len", []term.Term{hashM})
+
+	r := makeRule([]term.Term{lenHashM})
+	g := rule.NewNameGenerator(r)
+
+	assert.Equal(t, "h_m", g.NameForTerm(hashM))
+	assert.Equal(t, "l_h_m", g.NameForTerm(lenHashM))
+}
+
+func TestNameGenerator_DeepTermsUseStructuralNames(t *testing.T) {
+	t.Parallel()
+	// depth 3: enc(hash(len(x)))
+	x := term.NewVariable("x")
+	lenX := term.NewFunction("len", []term.Term{x})
+	hashLenX := term.NewFunction("hash", []term.Term{lenX})
+	encHashLenX := term.NewFunction("enc", []term.Term{hashLenX})
+
+	r := makeRule([]term.Term{encHashLenX})
+	g := rule.NewNameGenerator(r)
+
+	got := g.NameForTerm(encHashLenX)
+	assert.Equal(t, "e_h_l_x", got)
+}
+
+func TestNameGenerator_LateDeepTerm(t *testing.T) {
+	t.Parallel()
+	// Create a rule with no deep terms, then call NameForTerm on a deep term
+	// that wasn't seen during collection. Should still get a structural name.
+	r := makeRule([]term.Term{term.NewVariable("x")})
+	g := rule.NewNameGenerator(r)
+
+	x := term.NewVariable("x")
+	lenX := term.NewFunction("len", []term.Term{x})
+	hashLenX := term.NewFunction("hash", []term.Term{lenX})
+	encHashLenX := term.NewFunction("enc", []term.Term{hashLenX})
+
+	require.NotPanics(t, func() {
+		got := g.NameForTerm(encHashLenX)
+		assert.Equal(t, "e_h_l_x", got)
+	})
+}
+
+func TestNameGenerator_AbbrevCollision(t *testing.T) {
+	t.Parallel()
+	x := term.NewVariable("x")
+	hashX := term.NewFunction("hash", []term.Term{x})
+	hmacX := term.NewFunction("hmac", []term.Term{x})
+
+	r := rule.NewRule()
+	r.Name = "R"
+	r.LHS = []*rule.Fact{rule.NewFact("In", []term.Term{x}, rule.LinearFact)}
+	r.RHS = []*rule.Fact{rule.NewFact("Out", []term.Term{hashX, hmacX}, rule.LinearFact)}
+	g := rule.NewNameGenerator(r)
+
+	name1 := g.NameForTerm(hashX)
+	name2 := g.NameForTerm(hmacX)
+	assert.NotEqual(t, name1, name2)
+	// Sorted alphabetically: hash gets "h", hmac gets "hm".
+	assert.Equal(t, "h_x", name1)
+	assert.Equal(t, "hm_x", name2)
+}
+
+// TestNameGenerator_CollisionWithUserVariable verifies that generated names
+// do not shadow user variables. Repro from Codex finding #1:
+// In(m, h_m) -> Out(len(hash(m)), h_m) must not produce h_m for hash(m).
+func TestNameGenerator_CollisionWithUserVariable(t *testing.T) {
+	t.Parallel()
+	m := term.NewVariable("m")
+	hm := term.NewVariable("h_m")
+	hashM := term.NewFunction("hash", []term.Term{m})
+	lenHashM := term.NewFunction("len", []term.Term{hashM})
+
+	r := makeRuleWithLHS(
+		[]term.Term{m, hm},
+		[]term.Term{lenHashM, hm},
+	)
+	g := rule.NewNameGenerator(r)
+
+	// hash(m) must NOT get "h_m" because that's already a user variable.
+	hashName := g.NameForTerm(hashM)
+	assert.NotEqual(t, "h_m", hashName, "generated name must not collide with user variable h_m")
+	assert.Equal(t, "h_m_0", hashName)
+
+	// The user variable h_m keeps its original name.
+	assert.Equal(t, "h_m", g.NameForTerm(hm))
+}
+
+// TestNameGenerator_DeepStructuralNameAvoidsUserVariableCollision verifies that
+// deep structural names do not shadow user variables.
+func TestNameGenerator_DeepStructuralNameAvoidsUserVariableCollision(t *testing.T) {
+	t.Parallel()
+	t0 := term.NewVariable("t0")
+	lenT0 := term.NewFunction("len", []term.Term{t0})
+	hashLenT0 := term.NewFunction("hash", []term.Term{lenT0})
+	encHashLenT0 := term.NewFunction("enc", []term.Term{hashLenT0})
+
+	r := makeRuleWithLHS(
+		[]term.Term{t0},
+		[]term.Term{encHashLenT0, t0},
+	)
+	g := rule.NewNameGenerator(r)
+
+	deepName := g.NameForTerm(encHashLenT0)
+	assert.NotEqual(t, "t0", deepName, "deep name must not collide with user variable t0")
+	assert.Equal(t, "e_h_l_t0", deepName)
+
+	// The user variable t0 keeps its name.
+	assert.Equal(t, "t0", g.NameForTerm(t0))
+}
+
+// TestNameGenerator_Deterministic verifies that the same rule always produces
+// the same generated names.
+func TestNameGenerator_Deterministic(t *testing.T) {
+	t.Parallel()
+	m := term.NewVariable("m")
+	hashM := term.NewFunction("hash", []term.Term{m})
+	lenHashM := term.NewFunction("len", []term.Term{hashM})
+
+	for range 10 {
+		r := makeRule([]term.Term{lenHashM})
+		g := rule.NewNameGenerator(r)
+		assert.Equal(t, "h_m", g.NameForTerm(hashM))
+		assert.Equal(t, "l_h_m", g.NameForTerm(lenHashM))
+	}
+}
+
+// TestNameGenerator_OrderIndependent verifies that reordering RHS facts does
+// not change generated names.
+func TestNameGenerator_OrderIndependent(t *testing.T) {
+	t.Parallel()
+	x := term.NewVariable("x")
+	hashX := term.NewFunction("hash", []term.Term{x})
+	hmacX := term.NewFunction("hmac", []term.Term{x})
+
+	// Order A: hash before hmac.
+	rA := rule.NewRule()
+	rA.Name = "R"
+	rA.LHS = []*rule.Fact{rule.NewFact("In", []term.Term{x}, rule.LinearFact)}
+	rA.RHS = []*rule.Fact{rule.NewFact("Out", []term.Term{hashX, hmacX}, rule.LinearFact)}
+	gA := rule.NewNameGenerator(rA)
+
+	// Order B: hmac before hash.
+	rB := rule.NewRule()
+	rB.Name = "R"
+	rB.LHS = []*rule.Fact{rule.NewFact("In", []term.Term{x}, rule.LinearFact)}
+	rB.RHS = []*rule.Fact{rule.NewFact("Out", []term.Term{hmacX, hashX}, rule.LinearFact)}
+	gB := rule.NewNameGenerator(rB)
+
+	assert.Equal(t, gA.NameForTerm(hashX), gB.NameForTerm(hashX))
+	assert.Equal(t, gA.NameForTerm(hmacX), gB.NameForTerm(hmacX))
+}
+
+// TestNameGenerator_OrderIndependentWithCollision verifies stability when
+// suffix allocation is needed. Repro from Codex follow-up finding:
+// In(m, m_0, h_m) -> Out(hash(m), hash(m_0)) must produce the same names
+// regardless of whether hash(m) or hash(m_0) appears first in the RHS.
+func TestNameGenerator_OrderIndependentWithCollision(t *testing.T) {
+	t.Parallel()
+	m := term.NewVariable("m")
+	m0 := term.NewVariable("m_0")
+	hm := term.NewVariable("h_m")
+	hashM := term.NewFunction("hash", []term.Term{m})
+	hashM0 := term.NewFunction("hash", []term.Term{m0})
+
+	lhs := []term.Term{m, m0, hm}
+
+	// Order A: hash(m) before hash(m_0).
+	rA := makeRuleWithLHS(lhs, []term.Term{hashM, hashM0})
+	gA := rule.NewNameGenerator(rA)
+
+	// Order B: hash(m_0) before hash(m).
+	rB := makeRuleWithLHS(lhs, []term.Term{hashM0, hashM})
+	gB := rule.NewNameGenerator(rB)
+
+	assert.Equal(t, gA.NameForTerm(hashM), gB.NameForTerm(hashM),
+		"hash(m) name must be stable across RHS orderings")
+	assert.Equal(t, gA.NameForTerm(hashM0), gB.NameForTerm(hashM0),
+		"hash(m_0) name must be stable across RHS orderings")
+}
+
+func TestNameGenerator_LongStructuralNamesAreCompacted(t *testing.T) {
+	t.Parallel()
+
+	r := makeRule([]term.Term{
+		term.NewFunction("f", []term.Term{
+			term.NewVariable("somelongvar"),
+			term.NewVariable("anotherlongvar"),
+			term.NewVariable("thirdlongvar"),
+		}),
+	})
+	g := rule.NewNameGenerator(r)
+
+	name := g.NameForTerm(term.NewFunction("f", []term.Term{
+		term.NewVariable("somelongvar"),
+		term.NewVariable("anotherlongvar"),
+		term.NewVariable("thirdlongvar"),
+	}))
+
+	assert.LessOrEqual(t, len(name), 30)
+	assert.Equal(t, "f0", name)
+}
+
+func TestNameGenerator_LongStructuralCollisionStillCapped(t *testing.T) {
+	t.Parallel()
+
+	longTerm := term.NewFunction("f", []term.Term{
+		term.NewVariable("somelongvar"),
+		term.NewVariable("anotherlongvar"),
+		term.NewVariable("thirdlongvar"),
+	})
+
+	baseRule := makeRule([]term.Term{longTerm})
+	baseGen := rule.NewNameGenerator(baseRule)
+	baseName := baseGen.NameForTerm(longTerm)
+
+	collisionRule := makeRuleWithLHS(
+		[]term.Term{term.NewVariable(baseName)},
+		[]term.Term{longTerm},
+	)
+	collisionGen := rule.NewNameGenerator(collisionRule)
+	collisionName := collisionGen.NameForTerm(longTerm)
+
+	assert.NotEqual(t, baseName, collisionName)
+	assert.LessOrEqual(t, len(collisionName), 30)
+	assert.Equal(t, "f1", collisionName)
+}
+
+func TestNameGenerator_LongDeepNamesAreCompacted(t *testing.T) {
+	t.Parallel()
+
+	longHash := term.NewFunction("hash", []term.Term{
+		term.NewVariable("somelongvar"),
+		term.NewVariable("anotherlongvar"),
+		term.NewVariable("thirdlongvar"),
+	})
+	deepTerm := term.NewFunction("hmac", []term.Term{
+		longHash,
+		term.NewConstant[[]byte]([]byte{0x01}),
+	})
+
+	r := makeRule([]term.Term{deepTerm})
+	g := rule.NewNameGenerator(r)
+
+	assert.Equal(t, "h0", g.NameForTerm(longHash))
+	name := g.NameForTerm(deepTerm)
+	assert.Equal(t, "hm0", name)
+}
+
+// TestNameGenerator_LongCommonPrefixFunctionsCapped verifies that compact names
+// stay within maxGeneratedNameLen even when two function names share a long
+// common prefix, forcing shortestUniquePrefix to return a lengthy abbreviation.
+func TestNameGenerator_LongCommonPrefixFunctionsCapped(t *testing.T) {
+	t.Parallel()
+	x := term.NewVariable("x")
+	// Two functions that share a 28-char prefix, diverging only at the end.
+	f1 := term.NewFunction("abcdefghijklmnopqrstuvwxyzAA", []term.Term{x})
+	f2 := term.NewFunction("abcdefghijklmnopqrstuvwxyzBB", []term.Term{x})
+
+	r := rule.NewRule()
+	r.Name = "R"
+	r.LHS = []*rule.Fact{rule.NewFact("In", []term.Term{x}, rule.LinearFact)}
+	r.RHS = []*rule.Fact{rule.NewFact("Out", []term.Term{f1, f2}, rule.LinearFact)}
+	g := rule.NewNameGenerator(r)
+
+	name1 := g.NameForTerm(f1)
+	name2 := g.NameForTerm(f2)
+	assert.NotEqual(t, name1, name2)
+	assert.LessOrEqual(t, len(name1), 30, "compact name for f1 exceeds cap")
+	assert.LessOrEqual(t, len(name2), 30, "compact name for f2 exceeds cap")
+}
+
+func TestSanitizeName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"m", "m"},
+		{"$secret", "secret"},
+		{"~k", "k"},
+		{"$$double", "double"},
+		{"~$mixed", "mixed"},
+		{"", "x"},
+		{"$", "x"},
+		{"~", "x"},
+		{"hello_world", "hello_world"},
+		{"a-b", "ab"},
+		{"foo.bar", "foobar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			// sanitizeName is not exported, so test indirectly via NameForTerm
+			// on a variable with the given name.
+			r := makeRule([]term.Term{term.NewVariable("dummy")})
+			g := rule.NewNameGenerator(r)
+			got := g.NameForTerm(term.NewVariable(tt.input))
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestTermKeyInjectivity(t *testing.T) {
+	t.Parallel()
+	// A variable named "f(x)" and a function f(x) should produce different
+	// names, ensuring the type-prefixed termKey prevents cross-type collisions.
+	x := term.NewVariable("x")
+	funcFX := term.NewFunction("f", []term.Term{x})
+	varFX := term.NewVariable("f(x)")
+
+	r := rule.NewRule()
+	r.Name = "R"
+	r.LHS = []*rule.Fact{rule.NewFact("In", []term.Term{x}, rule.LinearFact)}
+	r.RHS = []*rule.Fact{rule.NewFact("Out", []term.Term{funcFX, varFX}, rule.LinearFact)}
+	g := rule.NewNameGenerator(r)
+
+	funcName := g.NameForTerm(funcFX)
+	varName := g.NameForTerm(varFX)
+	assert.NotEqual(t, funcName, varName)
+}

--- a/rule/translation.go
+++ b/rule/translation.go
@@ -20,6 +20,7 @@ package rule
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/specmon/specmon/data"
@@ -70,14 +71,18 @@ func BuildDAGForRule(r *Rule) *TermNode {
 //  1. The LHS contains all facts from the LHS of r.
 //  2. The RHS contains a fact with all variables from the RHS of r
 //     and pre-facts from function symbols of depth n.
-func GenerateStartRule(r *Rule, D *TermNode) *Rule {
+func GenerateStartRule(r *Rule, D *TermNode, names *NameGenerator, original map[*TermNode]term.Term) *Rule {
 	ruleVars := nonPublicRuleVars(r)
 
 	rhs := make([]*Fact, len(D.Leaves()))
 	hints := make([]term.Term, len(D.Leaves()))
 	for i, leaf := range D.Leaves() {
 		f := term.Must(term.AsFunction(leaf.Value()))
-		rhs[i] = NewFact(fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, f.Name), []term.Term{
+		termName := f.Name
+		if !strings.HasSuffix(termName, PreFactSuffix) {
+			termName = termNameForNode(names, original, leaf)
+		}
+		rhs[i] = NewFact(fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, termName), []term.Term{
 			term.NewFunction(term.PairFunctionName, ruleVars),
 		},
 			LinearFact,
@@ -111,15 +116,14 @@ func GenerateStartRule(r *Rule, D *TermNode) *Rule {
 // GenerateEndRule returns a new rule with the following properties:
 //
 //	TODO
-func GenerateEndRule(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding) *Rule {
+func GenerateEndRule(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding, names *NameGenerator, original map[*TermNode]term.Term) *Rule {
 	ruleVars := term.AsTerms(utils.Unique(Facts(r.RHS).Vars()))
 
 	lhs := make([]*Fact, D.Roots()[0].Children().Size())
 	for i, d := range D.Roots()[0].Children().AsSlice() {
-		f := term.Must(term.AsFunction(d.Value()))
-
 		u := U[d]
-		g := NewFact(fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, nameForTerm(f)), []term.Term{
+		termName := termNameForNode(names, original, d)
+		g := NewFact(fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, termName), []term.Term{
 			term.NewFunction(term.PairFunctionName, ruleVars),
 		}, LinearFact)
 
@@ -154,7 +158,7 @@ func GenerateEndRule(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding)
 		}
 
 		if d.Parents().Size() > 1 {
-			g.Name = fmt.Sprintf("%s_%s_%s_%d", SubtermName, r.Name, nameForTerm(f), u)
+			g.Name = fmt.Sprintf("%s_%s_%s_%d", SubtermName, r.Name, termName, u)
 		}
 
 		lhs[i] = g
@@ -245,14 +249,14 @@ func BuildDAG(n *TermNode) {
 	}
 }
 
-func LabelSubterms(n *TermNode, b *term.Binding) {
+func LabelSubterms(n *TermNode, b *term.Binding, names *NameGenerator, original map[*TermNode]term.Term) {
 	for _, c := range n.Children().AsSlice() {
-		ret := term.NewVariable(nameForTerm(c.Value()))
+		ret := term.NewVariable(names.NameForTerm(originalTerm(original, c)))
 
 		n.AddChildrenWithLabel(ret, c)
-		b.Set(c.Value(), ret)
+		b.Set(originalTerm(original, c), ret)
 
-		LabelSubterms(c, b)
+		LabelSubterms(c, b, names, original)
 	}
 }
 
@@ -278,29 +282,36 @@ func Translate(r *Rule /*, I data.Set[string]*/) []*Rule {
 		return []*Rule{r}
 	}
 
-	// Build a dependecny graph for the rule r.
-	// Work on a copy of r do avoid modifying the original rule.
+	// Build a dependency graph for the rule r.
+	// Work on a copy of r to avoid modifying the original rule.
 	D := BuildDAGForRule(r.Clone())
 
-	// emove constants and varibles from D.
+	// Remove constants and variables from D.
 	RemoveConstants(D)
 	RemoveVariables(D)
 
-	// Label subterms with variables.
-	F := term.NewBinding()
-	LabelSubterms(D, F)
-
-	// Keep mapping of subterms to variables prior to substitution.
-	O := term.NewBinding()
-	LabelSubterms(D, O)
-
-	// Replace subterms with variables.
-	ReplaceSubterms(D, F)
-
-	// If the depth of the DAG is 0, we don't need to do anything.
+	// If the depth of the DAG is 0, no decomposition is needed.
 	if D.Depth() == 0 {
 		return []*Rule{r}
 	}
+
+	names := NewNameGenerator(r)
+
+	// snapshotTerms captures the current Value() of each DAG node before
+	// LabelSubterms/ReplaceSubterms mutate them. Pointer identity of
+	// *TermNode keys is stable because DAG operations don't reallocate
+	// existing nodes.
+	original := snapshotTerms(D)
+
+	// Label subterms with variables.
+	F := term.NewBinding()
+	LabelSubterms(D, F, names, original)
+
+	// Keep mapping of subterms to variables prior to substitution.
+	O := F.Clone()
+
+	// Replace subterms with variables.
+	ReplaceSubterms(D, F)
 
 	// If the depth of the DAG is 1, we only need to add
 	// the required triggers.
@@ -313,6 +324,12 @@ func Translate(r *Rule /*, I data.Set[string]*/) []*Rule {
 			}
 		}
 
+		// Sort triggers so the output is deterministic regardless of
+		// the order that RHS/Act facts were listed in the original rule.
+		sort.Slice(triggers, func(i, j int) bool {
+			return triggers[i].String() < triggers[j].String()
+		})
+
 		R := r.Clone()
 		R.Attrs[TriggerAttributeName] = TermAttribute{triggers}
 
@@ -320,15 +337,15 @@ func Translate(r *Rule /*, I data.Set[string]*/) []*Rule {
 	}
 
 	// Add pre facts
-	AddPreFacts(D)
+	AddPreFacts(D, names, original)
 
 	var R []*Rule
 	U := make(map[*TermNode]int)
 
 	// Generate rules for the DAG.
-	R = append(R, GenerateStartRule(r, D))
-	R = append(R, GenerateMidRules(r, D, U, O)...)
-	R = append(R, GenerateEndRule(r, D, U, F))
+	R = append(R, GenerateStartRule(r, D, names, original))
+	R = append(R, GenerateMidRules(r, D, U, O, names, original)...)
+	R = append(R, GenerateEndRule(r, D, U, F, names, original))
 
 	// Prefix generated rule names with the name of rule r.
 	var count int
@@ -371,7 +388,7 @@ func RemoveConstants(D *TermNode) *TermNode {
 	return D
 }
 
-func GenerateMidRules(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding) []*Rule {
+func GenerateMidRules(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding, names *NameGenerator, original map[*TermNode]term.Term) []*Rule {
 	var rules []*Rule
 
 	ruleVarsNonPublic := nonPublicRuleVars(r)
@@ -405,15 +422,16 @@ func GenerateMidRules(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding
 		rhs := make([]*Fact, d.Parents().Size())
 		for i := range d.Parents().AsSlice() {
 			var g *Fact
+			termName := termNameForNode(names, original, d)
 			if d.Parents().Size() > 1 {
-				g = NewFact(fmt.Sprintf("%s_%s_%s_%d", SubtermName, r.Name, nameForTerm(f), i), []term.Term{
+				g = NewFact(fmt.Sprintf("%s_%s_%s_%d", SubtermName, r.Name, termName, i), []term.Term{
 					// Include all variables of the rule in the fact.
 					// Then, we don't have to add varsFacts for intermediate rules.
 					term.NewFunction(term.PairFunctionName, fVars),
 					term.NewFunction(f.Name, f.Args),
 				}, LinearFact)
 			} else {
-				g = NewFact(fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, nameForTerm(f)), []term.Term{
+				g = NewFact(fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, termName), []term.Term{
 					// Include all variables of the rule in the fact.
 					// Then, we don't have to add varsFacts for intermediate rules.
 					term.NewFunction(term.PairFunctionName, fVars),
@@ -456,7 +474,7 @@ func GenerateMidRules(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding
 			// and can be used directly.
 			fName := f.Name
 			if !strings.HasSuffix(fName, PreFactSuffix) {
-				fName = nameForTerm(f)
+				fName = termNameForNode(names, original, c)
 			}
 
 			factName := fmt.Sprintf("%s_%s_%s", SubtermName, r.Name, fName)
@@ -494,13 +512,14 @@ func GenerateMidRules(r *Rule, D *TermNode, U map[*TermNode]int, F *term.Binding
 }
 
 // AddPreFacts adds Pre facts for all leave nodes that are observable.
-func AddPreFacts(D *TermNode) *TermNode {
+func AddPreFacts(D *TermNode, names *NameGenerator, original map[*TermNode]term.Term) *TermNode {
 	D.Traverse(data.TraverseDown, data.TraverseDFS, true, func(d *TermNode, w term.Term, _ int) bool {
 		// If the node is a leaf, we add a pre fact.
 		// w != nil ensures that we don't run into an endless loop.
 		if d.Children().Empty() && w != nil {
 			f := term.Must(term.AsFunction(d.Value()))
-			g := term.NewFunction(nameForTerm(f)+"_Pre", term.AsTerms(term.Terms(f.Args).Vars()))
+			name := names.NameForTerm(originalTerm(original, d))
+			g := term.NewFunction(name+"_Pre", term.AsTerms(term.Terms(f.Args).Vars()))
 			d.AddChildren(data.NewDAGNode[term.Term, term.Term](g))
 		}
 
@@ -516,24 +535,36 @@ func FindTerm(n *TermNode, arg term.Term) *TermNode {
 	})
 }
 
-// nameForTerm returns a string representation of a term.
-// It is used to generate unique names for return values of functions.
-func nameForTerm(t term.Term) string {
-	switch t := t.(type) {
-	case *term.Function:
-		s := t.Name
-
-		for _, a := range t.Args {
-			s += nameForTerm(a)
+func snapshotTerms(D *TermNode) map[*TermNode]term.Term {
+	original := make(map[*TermNode]term.Term)
+	D.Traverse(data.TraverseDown, data.TraverseDFS, true, func(d *TermNode, _ term.Term, _ int) bool {
+		if d != nil && d.Value() != nil {
+			original[d] = d.Value()
 		}
+		return true
+	})
+	return original
+}
 
-		return s
-	case *term.Variable:
-		return t.Name
-	// Constants are handled by the default case.
-	default:
-		return strings.ReplaceAll(t.String(), "'", "")
+func originalTerm(original map[*TermNode]term.Term, node *TermNode) term.Term {
+	if node == nil {
+		return nil
 	}
+	if t, ok := original[node]; ok {
+		return t
+	}
+	return node.Value()
+}
+
+func termNameForNode(names *NameGenerator, original map[*TermNode]term.Term, node *TermNode) string {
+	if names == nil {
+		return ""
+	}
+	t := originalTerm(original, node)
+	if t == nil {
+		return ""
+	}
+	return names.NameForTerm(t)
 }
 
 func nonPublicRuleVars(r *Rule) []term.Term {

--- a/rule/translation_integration_test.go
+++ b/rule/translation_integration_test.go
@@ -2,6 +2,7 @@ package rule_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"github.com/specmon/specmon/cmd"
 	"github.com/specmon/specmon/parser"
 	"github.com/specmon/specmon/rule"
+	"github.com/specmon/specmon/term"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,6 +54,144 @@ func TestTranslationFromFiles(t *testing.T) {
 			assertRulesEqual(t, expectedRules, actualRules)
 		})
 	}
+}
+
+// TestTranslateOrderIndependent verifies that reordering RHS facts in a rule
+// produces identical decomposed output. This is an end-to-end regression test
+// for naming stability through the full Translate pipeline.
+//
+// Mid-rule numbering (R_0, R_1, ...) depends on DAG traversal order and may
+// differ between orderings, so we compare rule bodies after stripping the
+// rule name from each string representation.
+func TestTranslateOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	m := term.NewVariable("m")
+	k := term.NewVariable("k")
+	hashM := term.NewFunction("hash", []term.Term{m})
+	hmacK := term.NewFunction("hmac", []term.Term{k})
+	lenHashM := term.NewFunction("len", []term.Term{hashM})
+
+	lhs := []*rule.Fact{
+		rule.NewFact("State0", []term.Term{m, k}, rule.LinearFact),
+	}
+
+	// Order A: Out(len(hash(m))) before Out(hmac(k)).
+	rA := &rule.Rule{
+		Name: "R",
+		LHS:  lhs,
+		Act:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("Out", []term.Term{lenHashM}, rule.LinearFact),
+			rule.NewFact("Out2", []term.Term{hmacK}, rule.LinearFact),
+			rule.NewFact("State1", []term.Term{m, k}, rule.LinearFact),
+		},
+		Attrs: make(map[string]rule.Attribute),
+	}
+
+	// Order B: Out(hmac(k)) before Out(len(hash(m))).
+	rB := &rule.Rule{
+		Name: "R",
+		LHS:  lhs,
+		Act:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("Out2", []term.Term{hmacK}, rule.LinearFact),
+			rule.NewFact("Out", []term.Term{lenHashM}, rule.LinearFact),
+			rule.NewFact("State1", []term.Term{m, k}, rule.LinearFact),
+		},
+		Attrs: make(map[string]rule.Attribute),
+	}
+
+	rulesA := rule.Translate(rA)
+	rulesB := rule.Translate(rB)
+
+	require.Len(t, rulesB, len(rulesA), "Different number of decomposed rules")
+
+	// Compare the set of rule bodies, ignoring mid-rule numbering.
+	bodiesA := normalizedRuleBodies(rulesA)
+	bodiesB := normalizedRuleBodies(rulesB)
+
+	sort.Strings(bodiesA)
+	sort.Strings(bodiesB)
+
+	require.Equal(t, bodiesA, bodiesB,
+		"Decomposed rule bodies differ between RHS orderings")
+}
+
+// TestTranslateDepth1OrderIndependent verifies that reordering RHS facts in a
+// depth-1 rule (single-level function applications, no mid-rules) produces
+// identical trigger attributes regardless of fact ordering.
+func TestTranslateDepth1OrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	m := term.NewVariable("m")
+	k := term.NewVariable("k")
+	hashM := term.NewFunction("hash", []term.Term{m})
+	hmacK := term.NewFunction("hmac", []term.Term{k})
+
+	lhs := []*rule.Fact{
+		rule.NewFact("State0", []term.Term{m, k}, rule.LinearFact),
+	}
+
+	// Order A: Out(hash(m)) before Out(hmac(k)).
+	rA := &rule.Rule{
+		Name: "R",
+		LHS:  lhs,
+		Act:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("Out", []term.Term{hashM}, rule.LinearFact),
+			rule.NewFact("Out2", []term.Term{hmacK}, rule.LinearFact),
+			rule.NewFact("State1", []term.Term{m, k}, rule.LinearFact),
+		},
+		Attrs: make(map[string]rule.Attribute),
+	}
+
+	// Order B: Out(hmac(k)) before Out(hash(m)).
+	rB := &rule.Rule{
+		Name: "R",
+		LHS:  lhs,
+		Act:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("Out2", []term.Term{hmacK}, rule.LinearFact),
+			rule.NewFact("Out", []term.Term{hashM}, rule.LinearFact),
+			rule.NewFact("State1", []term.Term{m, k}, rule.LinearFact),
+		},
+		Attrs: make(map[string]rule.Attribute),
+	}
+
+	rulesA := rule.Translate(rA)
+	rulesB := rule.Translate(rB)
+
+	require.Len(t, rulesA, 1, "Depth-1 decomposition should produce a single rule")
+	require.Len(t, rulesB, 1, "Depth-1 decomposition should produce a single rule")
+
+	// The RHS fact ordering faithfully mirrors the original rule, so it may
+	// differ. What must be stable is the trigger attribute.
+	trigA := rulesA[0].Attrs[rule.TriggerAttributeName]
+	trigB := rulesB[0].Attrs[rule.TriggerAttributeName]
+	require.Equal(t, fmt.Sprint(trigA), fmt.Sprint(trigB),
+		"Depth-1 trigger attributes differ between RHS orderings")
+}
+
+// normalizedRuleBodies strips the rule name from each rule's string
+// representation so that mid-rule numbering (R_0 vs R_1) does not
+// affect comparison. The attributes, facts, and generated variable
+// names are preserved.
+func normalizedRuleBodies(rules []*rule.Rule) []string {
+	bodies := make([]string, len(rules))
+	for i, r := range rules {
+		s := r.String()
+		// Format: "rule NAME ...:\n  body"
+		// Strip "rule NAME" prefix, keep attributes and body.
+		if idx := strings.Index(s, " ["); idx >= 0 {
+			bodies[i] = s[idx:]
+		} else if idx := strings.Index(s, ":\n"); idx >= 0 {
+			bodies[i] = s[idx:]
+		} else {
+			bodies[i] = s
+		}
+	}
+	return bodies
 }
 
 // assertRulesEqual compares two rule slices, handling ordering and formatting differences.

--- a/testdata/translation/existing_hints/expected.spthy
+++ b/testdata/translation/existing_hints/expected.spthy
@@ -3,7 +3,8 @@ begin
 
 rule TestRuleWithHint [ hint=[<len(y), len_y>] ]:
   [ State0(m) ] 
-  --> 
-  [ Out(len(hash(m))), State1(m) ]
+  -->
+  [ Out(len(hash(m)))
+  , State1(m) ]
 
 end

--- a/testdata/translation/existing_triggers/expected.spthy
+++ b/testdata/translation/existing_triggers/expected.spthy
@@ -3,7 +3,8 @@ begin
 
 rule TestRuleWithTrigger [ trigger=[<hash(x), hash_x>] ]:
   [ State0(m) ] 
-  --> 
-  [ Out(len(hash(m))), State1(m) ]
+  -->
+  [ Out(len(hash(m)))
+  , State1(m) ]
 
 end

--- a/testdata/translation/no_decomp_attribute/expected.spthy
+++ b/testdata/translation/no_decomp_attribute/expected.spthy
@@ -1,9 +1,10 @@
 theory NoDecompAttribute
 begin
 
-rule TestRule [no-decomp]:
+rule TestRule [ no-decomp ]:
   [ State0(m) ] 
-  --> 
-  [ Out(len(hash(m))), State1(m) ]
+  -->
+  [ Out(len(hash(m)))
+  , State1(m) ]
 
 end

--- a/testdata/translation/no_decomposition/expected.spthy
+++ b/testdata/translation/no_decomposition/expected.spthy
@@ -3,7 +3,7 @@ begin
 
 rule SimpleRule:
   [ State0(x) ] 
-  --> 
+  -->
   [ State1(x) ]
 
 end

--- a/testdata/translation/simple_function/expected.spthy
+++ b/testdata/translation/simple_function/expected.spthy
@@ -1,24 +1,25 @@
 theory SimpleFunction
 begin
 
-rule TestRule_Start [ hint=[<hash(m), hashm>] ]:
-  [ State0(m) ] 
+rule TestRule_Start [ hint=[<hash(m), h_m>] ]:
+  [ State0(m) ]
   -->
-  [ ST_TestRule_hashm_Pre(<m>) ]
+  [ ST_TestRule_h_m_Pre(<m>) ]
 
-rule TestRule_0 [ trigger=[<len(hashm), lenhashm>] ]:
-  [ ST_TestRule_hashm(<m>, hashm) ] 
+rule TestRule_0 [ trigger=[<len(h_m), l_h_m>] ]:
+  [ ST_TestRule_h_m(<m>, h_m) ]
   -->
-  [ ST_TestRule_lenhashm(<m>, len(hashm)) ]
+  [ ST_TestRule_l_h_m(<m>, len(h_m)) ]
 
-rule TestRule_1 [ trigger=[<hash(m), hashm>] ]:
-  [ ST_TestRule_hashm_Pre(<m>) ] 
+rule TestRule_1 [ trigger=[<hash(m), h_m>] ]:
+  [ ST_TestRule_h_m_Pre(<m>) ]
   -->
-  [ ST_TestRule_hashm(<m>, hash(m)) ]
+  [ ST_TestRule_h_m(<m>, hash(m)) ]
 
 rule TestRule_End:
-  [ ST_TestRule_lenhashm(<m>, lenhashm) ] 
+  [ ST_TestRule_l_h_m(<m>, l_h_m) ]
   -->
-  [ Out(lenhashm), State1(m) ]
+  [ Out(l_h_m)
+  , State1(m) ]
 
 end


### PR DESCRIPTION
Introduce a NameGenerator that produces short, readable names for intermediate computation results during rule decomposition. Original variable names are preserved; only function application results are renamed.

Naming strategy:
- Function abbreviations use the shortest unique prefix among all functions in a rule (e.g., hash→h, hmac→hm), computed dynamically.
- Structural names join the abbreviation with argument names (e.g., h_m for hash(m), l_h_m for len(hash(m))).
- When a structural name exceeds 30 characters or contains a compacted child, a compact abbreviation+index form is used (e.g., hm0, hm1).

Guarantees:
- Generated names never collide with user-defined variable or function names (tracked via a reserved set).
- Output is deterministic and independent of RHS fact ordering (terms are pre-allocated in sorted depth+key order, depth-1 triggers are sorted).

Also simplifies rule/translation.go by removing the variable renaming pass (buildVariableBinding) and redundant DAG construction, and removes the parser's function name validation since collision avoidance is now handled entirely by the generator.