### PR TITLE
chore: Upgrade the toolchain to Go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.5
+          version: v2.11.3
 
       - name: Run tests
         run: go test -v -coverprofile=coverage.out ./...

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -121,18 +121,13 @@ type multiplexedReader struct {
 	eventChan chan []byte
 	closeChan chan struct{}
 	closeOnce sync.Once
-	ctx       context.Context
-	cancel    context.CancelFunc
 }
 
 func newMultiplexedReader(listener net.Listener) *multiplexedReader {
-	ctx, cancel := context.WithCancel(context.Background())
 	mr := &multiplexedReader{
 		listener:  listener,
 		eventChan: make(chan []byte, 1000), // Buffer for events
 		closeChan: make(chan struct{}),
-		ctx:       ctx,
-		cancel:    cancel,
 	}
 
 	// Start accepting connections in the background
@@ -144,14 +139,14 @@ func newMultiplexedReader(listener net.Listener) *multiplexedReader {
 func (mr *multiplexedReader) acceptConnections() {
 	for {
 		select {
-		case <-mr.ctx.Done():
+		case <-mr.closeChan:
 			return
 		default:
 			conn, err := mr.listener.Accept()
 			if err != nil {
 				select {
-				case <-mr.ctx.Done():
-					return // Context was cancelled, expected error
+				case <-mr.closeChan:
+					return // Listener was closed, expected error
 				default:
 					log.Fatalf("Error accepting connection: %v\n", err)
 					continue
@@ -182,7 +177,7 @@ func (mr *multiplexedReader) handleConnection(conn net.Conn) {
 		select {
 		case mr.eventChan <- event:
 			// Event sent successfully
-		case <-mr.ctx.Done():
+		case <-mr.closeChan:
 			return // Multiplexer is being closed
 		}
 	}
@@ -204,14 +199,13 @@ func (mr *multiplexedReader) Read(p []byte) (n int, err error) {
 		}
 		copy(p, event)
 		return len(event), nil
-	case <-mr.ctx.Done():
+	case <-mr.closeChan:
 		return 0, io.EOF
 	}
 }
 
 func (mr *multiplexedReader) Close() error {
 	mr.closeOnce.Do(func() {
-		mr.cancel()
 		mr.listener.Close()
 		close(mr.closeChan)
 	})

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760527613,
-        "narHash": "sha256-AGdZ+tZgDP0IP+KN2zt29U15m2ACz60WgrgiITOKHbw=",
+        "lastModified": 1774024870,
+        "narHash": "sha256-sY714A2nSxeHpnUcHxRP3MUFqN8u+8exKeOHxs7Lm2E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f5d84dd15f512c1ea8d2bf52d66a1ed20577e10",
+        "rev": "6e083a90b396913570ec475a6e19250a53653bdf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       in
       pkgs.mkShell {
         buildInputs = [
-          pkgs.go
+          pkgs.go_1_26
 	  pkgs.gotools
 	  pkgs.gopls
 	  pkgs.golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/specmon/specmon
 
-go 1.25
+go 1.26
 
 require (
 	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df


### PR DESCRIPTION
  This PR upgrades the project toolchain to Go 1.26 and aligns CI/linting
  with that change.

  Changes:
  - bump `go.mod` to `go 1.26`
  - update `flake.lock`
  - pin the Nix dev shell to `pkgs.go_1_26`
  - update the CI lint step to `golangci-lint v2.11.3`

  To keep lint green with the newer `golangci-lint`, this PR also refactors
  `multiplexedReader` to use `closeChan` as its shutdown signal instead of
  storing a `context.CancelFunc`. This preserves the existing shutdown
  behavior and removes the `gosec` `G118` warning.