### PR TITLE
feat(parser): Support boolean operators in #ifdef

### DIFF
--- a/docs/src/content/docs/specifications/unified-models.md
+++ b/docs/src/content/docs/specifications/unified-models.md
@@ -87,6 +87,27 @@ macros:
 
 This pattern keeps the rules unchanged while swapping the macro expansions based on your chosen preprocessor symbol.
 
+### Boolean operators in `#ifdef`
+
+Conditions accept `not`, `&`, `|`, and parentheses, matching Tamarin's preprocessor. This lets a single condition gate a section without introducing an extra positive sentinel define.
+
+```tamarin
+#ifdef not SPECMON
+// Verification-only section: included unless --defines SPECMON is set.
+#endif
+
+#ifdef Properties & not Sanity
+// Included when Properties is defined and Sanity is not.
+#endif
+
+#ifdef (Properties | Sanity) & not Release
+// Included when at least one of Properties or Sanity is defined,
+// and Release is not.
+#endif
+```
+
+A bare identifier without operators continues to work as before.
+
 ### Monitoring-specific setup (optional)
 
 Some models include monitoring-only setup rules (for example, reading keys from instrumentation events) and verification-only setup rules (for example, generating fresh keys with `Fr`). Keep these differences minimal and tightly scoped.

--- a/parser/preprocessor.go
+++ b/parser/preprocessor.go
@@ -82,8 +82,7 @@ func (p *Preprocessor) handlePreprocessor(node *sitter.Node, out *bytes.Buffer) 
 			return // No condition found
 		}
 
-		condition := conditionNode.Utf8Text(p.source)
-		if p.defines[condition] {
+		if p.evalCondition(conditionNode) {
 			// Condition is true, process all 'consequence' nodes
 			consequenceNodes := childrenByFieldName(node, "consequence")
 			for _, conseqNode := range consequenceNodes {
@@ -97,4 +96,71 @@ func (p *Preprocessor) handlePreprocessor(node *sitter.Node, out *bytes.Buffer) 
 			}
 		}
 	}
+}
+
+// evalCondition evaluates an ifdef condition node, supporting the grammar's
+// nested boolean operators: ident, ifdef_nested, ifdef_not, ifdef_and, ifdef_or.
+func (p *Preprocessor) evalCondition(node *sitter.Node) bool {
+	switch node.Kind() {
+	case "ident":
+		return p.defines[node.Utf8Text(p.source)]
+	case "ifdef_nested":
+		// '(' formula ')'
+		for i := uint(0); i < node.ChildCount(); i++ {
+			c := node.Child(i)
+			if isFormula(c) {
+				return p.evalCondition(c)
+			}
+		}
+		return false
+	case "ifdef_not":
+		// 'not' formula
+		for i := uint(0); i < node.ChildCount(); i++ {
+			c := node.Child(i)
+			if isFormula(c) {
+				return !p.evalCondition(c)
+			}
+		}
+		return false
+	case "ifdef_and":
+		left, right := formulaOperands(node)
+		if left == nil || right == nil {
+			return false
+		}
+		return p.evalCondition(left) && p.evalCondition(right)
+	case "ifdef_or":
+		left, right := formulaOperands(node)
+		if left == nil || right == nil {
+			return false
+		}
+		return p.evalCondition(left) || p.evalCondition(right)
+	default:
+		// Fallback: treat the entire text as a single ident for backward compat.
+		return p.defines[node.Utf8Text(p.source)]
+	}
+}
+
+func isFormula(n *sitter.Node) bool {
+	switch n.Kind() {
+	case "ident", "ifdef_nested", "ifdef_not", "ifdef_and", "ifdef_or":
+		return true
+	}
+	return false
+}
+
+func formulaOperands(node *sitter.Node) (*sitter.Node, *sitter.Node) {
+	var left, right *sitter.Node
+	for i := uint(0); i < node.ChildCount(); i++ {
+		c := node.Child(i)
+		if !isFormula(c) {
+			continue
+		}
+		if left == nil {
+			left = c
+		} else {
+			right = c
+			break
+		}
+	}
+	return left, right
 }

--- a/parser/preprocessor_test.go
+++ b/parser/preprocessor_test.go
@@ -1,0 +1,160 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package parser
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// runPreprocessor parses src with the spthy grammar and applies the
+// preprocessor with the given defines, returning the resulting source.
+func runPreprocessor(t *testing.T, src string, defines []string) string {
+	t.Helper()
+
+	tree, err := Parse(context.Background(), []byte(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	pp := NewPreprocessor([]byte(src), defines)
+	return string(pp.Run(tree.RootNode()))
+}
+
+// theoryWithIfdef wraps an #ifdef block in a minimal theory so the
+// tree-sitter grammar accepts it. The consequence and alternative are
+// distinguished by formal comments whose identifiers we check for in
+// the preprocessed output.
+func theoryWithIfdef(condition string) string {
+	return "theory T begin\n" +
+		"#ifdef " + condition + "\n" +
+		"OnConseq {* on *}\n" +
+		"#else\n" +
+		"OnAlt {* off *}\n" +
+		"#endif\n" +
+		"end\n"
+}
+
+func TestPreprocessorIfdef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		condition  string
+		defines    []string
+		wantConseq bool
+	}{
+		{
+			name:       "bare ident defined",
+			condition:  "MONITOR",
+			defines:    []string{"MONITOR"},
+			wantConseq: true,
+		},
+		{
+			name:       "bare ident undefined",
+			condition:  "MONITOR",
+			defines:    nil,
+			wantConseq: false,
+		},
+		{
+			name:       "not undefined",
+			condition:  "not MONITOR",
+			defines:    nil,
+			wantConseq: true,
+		},
+		{
+			name:       "not defined",
+			condition:  "not MONITOR",
+			defines:    []string{"MONITOR"},
+			wantConseq: false,
+		},
+		{
+			name:       "and both defined",
+			condition:  "Properties & Sanity",
+			defines:    []string{"Properties", "Sanity"},
+			wantConseq: true,
+		},
+		{
+			name:       "and one missing",
+			condition:  "Properties & Sanity",
+			defines:    []string{"Properties"},
+			wantConseq: false,
+		},
+		{
+			name:       "or one defined",
+			condition:  "Properties | Sanity",
+			defines:    []string{"Sanity"},
+			wantConseq: true,
+		},
+		{
+			name:       "or neither defined",
+			condition:  "Properties | Sanity",
+			defines:    nil,
+			wantConseq: false,
+		},
+		{
+			name:       "parenthesised grouping selects or-branch",
+			condition:  "(Properties | Sanity) & not Release",
+			defines:    []string{"Sanity"},
+			wantConseq: true,
+		},
+		{
+			name:       "parenthesised grouping blocked by negation",
+			condition:  "(Properties | Sanity) & not Release",
+			defines:    []string{"Sanity", "Release"},
+			wantConseq: false,
+		},
+		{
+			name:       "compound positive and negative",
+			condition:  "Properties & not Sanity",
+			defines:    []string{"Properties"},
+			wantConseq: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			src := theoryWithIfdef(tc.condition)
+			out := runPreprocessor(t, src, tc.defines)
+
+			hasConseq := strings.Contains(out, "OnConseq")
+			hasAlt := strings.Contains(out, "OnAlt")
+
+			if tc.wantConseq && !hasConseq {
+				t.Errorf("condition %q with defines %v: expected consequence; output:\n%s",
+					tc.condition, tc.defines, out)
+			}
+			if tc.wantConseq && hasAlt {
+				t.Errorf("condition %q with defines %v: alternative should be omitted; output:\n%s",
+					tc.condition, tc.defines, out)
+			}
+			if !tc.wantConseq && !hasAlt {
+				t.Errorf("condition %q with defines %v: expected alternative; output:\n%s",
+					tc.condition, tc.defines, out)
+			}
+			if !tc.wantConseq && hasConseq {
+				t.Errorf("condition %q with defines %v: consequence should be omitted; output:\n%s",
+					tc.condition, tc.defines, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The preprocessor previously treated the entire #ifdef condition as a single key into the defines map, so a condition like `not MONITOR` would look up `defines["not MONITOR"]` and always evaluate false. The grammar already accepts ident, `( formula )`, `not formula`, `formula & formula`, and `formula | formula`.

evalCondition now walks the condition AST and evaluates each operator recursively. Unknown node kinds fall back to the previous single-ident lookup so existing specs are unaffected.

Specs can now write `#ifdef not MONITOR`, `#ifdef Properties & not Sanity`, and other compound guards to gate verification-only sections without introducing a positive sentinel define.