### PR TITLE
chore(flake): Add gofumpt to the dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         buildInputs = [
           pkgs.go_1_26
 	  pkgs.gotools
+	  pkgs.gofumpt
 	  pkgs.gopls
 	  pkgs.golangci-lint
 	  pkgs.nodejs


### PR DESCRIPTION
golangci-lint enforces gofumpt formatting; making the formatter available alongside gopls and golangci-lint in the Nix dev shell lets contributors run `gofumpt -w` without an extra install step.