### PR TITLE
refactor(rule): Replace deepcopy with hand-rolled Rule.Clone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/specmon/specmon
 go 1.26
 
 require (
-	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/fatih/color v1.18.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
-github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rule/rules.go
+++ b/rule/rules.go
@@ -27,7 +27,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/barkimedes/go-deepcopy"
 	"github.com/specmon/specmon/term"
 	"golang.org/x/exp/maps"
 )
@@ -221,9 +220,39 @@ func (r *Rule) IsGround() bool {
 	return true
 }
 
+// Clone returns a copy of r with independent LHS/Act/RHS slice headers and
+// an independent Attrs map. Facts and terms within those slices are
+// **shared** with the original rule — callers must treat the returned
+// rule's facts and their args as read-only.
+//
+// Returns nil when r is nil. When r.Attrs is nil, the clone's Attrs is an
+// empty (non-nil) map so callers can always assign into it.
 func (r *Rule) Clone() *Rule {
-	// deepcopy preserves the type.
-	return deepcopy.MustAnything(r).(*Rule)
+	if r == nil {
+		return nil
+	}
+
+	clone := &Rule{
+		Name: r.Name,
+		LHS:  append([]*Fact(nil), r.LHS...),
+		Act:  append([]*Fact(nil), r.Act...),
+		RHS:  append([]*Fact(nil), r.RHS...),
+	}
+
+	clone.Attrs = make(map[string]Attribute, len(r.Attrs))
+	for k, attr := range r.Attrs {
+		switch v := attr.(type) {
+		case StringAttribute:
+			clone.Attrs[k] = StringAttribute{Value: v.Value}
+		case TermAttribute:
+			terms := append([]term.Term(nil), v.Value...)
+			clone.Attrs[k] = TermAttribute{Value: terms}
+		default:
+			panic(fmt.Sprintf("rule.Clone: unknown Attribute type %T", attr))
+		}
+	}
+
+	return clone
 }
 
 func SortRule(r *Rule) {

--- a/rule/rules_test.go
+++ b/rule/rules_test.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package rule_test
+
+import (
+	"testing"
+
+	"github.com/specmon/specmon/rule"
+	"github.com/specmon/specmon/term"
+)
+
+// Rule.Clone documents that LHS/Act/RHS slice headers and Attrs map are
+// independent of the original, while facts and terms inside are shared.
+// These tests pin both halves of that contract.
+func TestRuleCloneSliceHeadersAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	fact := rule.NewFact("F", []term.Term{term.NewVariable("x")}, rule.LinearFact)
+	original := &rule.Rule{
+		Name:  "R",
+		LHS:   []*rule.Fact{fact},
+		Act:   []*rule.Fact{fact},
+		RHS:   []*rule.Fact{fact},
+		Attrs: map[string]rule.Attribute{},
+	}
+
+	clone := original.Clone()
+
+	// Mutating the clone's slice headers must not touch the original.
+	clone.LHS = append(clone.LHS, rule.NewFact("G", nil, rule.LinearFact))
+	if len(original.LHS) != 1 {
+		t.Errorf("appending to clone.LHS leaked into original.LHS (size %d, want 1)", len(original.LHS))
+	}
+}
+
+func TestRuleCloneAttrsMapIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := &rule.Rule{
+		Name: "R",
+		Attrs: map[string]rule.Attribute{
+			"comment": rule.StringAttribute{Value: "first"},
+		},
+	}
+
+	clone := original.Clone()
+
+	clone.Attrs["comment"] = rule.StringAttribute{Value: "second"}
+	if got := original.Attrs["comment"].(rule.StringAttribute).Value; got != "first" {
+		t.Errorf("clone.Attrs write leaked into original (got %q, want %q)", got, "first")
+	}
+}
+
+func TestRuleCloneTermAttributeSliceIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := &rule.Rule{
+		Name: "R",
+		Attrs: map[string]rule.Attribute{
+			rule.TriggerAttributeName: rule.TermAttribute{
+				Value: []term.Term{term.NewVariable("x"), term.NewVariable("y")},
+			},
+		},
+	}
+
+	clone := original.Clone()
+
+	cloneAttr := clone.Attrs[rule.TriggerAttributeName].(rule.TermAttribute)
+	cloneAttr.Value[0] = term.NewVariable("z")
+
+	origAttr := original.Attrs[rule.TriggerAttributeName].(rule.TermAttribute)
+	if got := origAttr.Value[0].(*term.Variable).Name; got != "x" {
+		t.Errorf("mutating clone TermAttribute slice element leaked into original (got %q, want %q)", got, "x")
+	}
+}
+
+func TestRuleCloneSharesFactPointers(t *testing.T) {
+	t.Parallel()
+
+	// Document the shallow-fact-sharing contract so the test fails
+	// loudly if a future refactor switches to deep-copying facts.
+	fact := rule.NewFact("F", []term.Term{term.NewVariable("x")}, rule.LinearFact)
+	original := &rule.Rule{
+		Name: "R",
+		LHS:  []*rule.Fact{fact},
+	}
+
+	clone := original.Clone()
+
+	if clone.LHS[0] != original.LHS[0] {
+		t.Error("Clone deep-copied fact pointer; the API contract is shallow-fact-sharing")
+	}
+}
+
+func TestRuleCloneNilRule(t *testing.T) {
+	t.Parallel()
+
+	var r *rule.Rule
+	if got := r.Clone(); got != nil {
+		t.Errorf("nil.Clone() = %v; want nil", got)
+	}
+}
+
+func TestRuleCloneNilAttrsBecomesEmpty(t *testing.T) {
+	t.Parallel()
+
+	original := &rule.Rule{Name: "R", Attrs: nil}
+
+	clone := original.Clone()
+
+	if clone.Attrs == nil {
+		t.Fatal("Clone of rule with nil Attrs returned nil Attrs; expected non-nil empty map")
+	}
+	if len(clone.Attrs) != 0 {
+		t.Errorf("Clone of rule with nil Attrs returned non-empty map: %v", clone.Attrs)
+	}
+
+	// Caller must be able to assign into the clone's Attrs.
+	clone.Attrs["x"] = rule.StringAttribute{Value: "y"}
+	if _, ok := original.Attrs["x"]; ok {
+		t.Error("assigning to clone.Attrs leaked into original Attrs (which was nil)")
+	}
+}


### PR DESCRIPTION
Drop the github.com/barkimedes/go-deepcopy dependency from Rule.Clone in favour of a small hand-rolled copy. deepcopy uses reflection over the entire object graph, which is slow on hot paths and pulls in a transitive module just to copy a rule plus its attribute map.

The new Clone:
- shallow-copies the LHS/Act/RHS *Fact slices (facts and the terms in their args are shared with the original)
- always allocates a fresh, possibly-empty Attrs map (a nil source map becomes an empty map so callers can always assign into it)
- deep-copies each Attribute by switching on the concrete type, copying the StringAttribute.Value string and the TermAttribute.Value slice
- panics for unknown Attribute types so a future addition cannot silently alias

The shallow-fact-sharing contract is documented on Clone itself; every current caller treats the returned rule's facts and args as read-only (verified in rule/translation.go and the monitor command path).

The previous Clone delegated to deepcopy.MustAnything, which panicked on nil input; the new Clone returns nil instead.

rule/rules_test.go adds direct coverage for the contract:
  - LHS slice header is independent
  - Attrs map is independent
  - TermAttribute.Value slice is independent
  - Fact pointers are shared (pins the shallow contract)
  - nil rule returns nil
  - nil Attrs becomes a writable empty map

This removes the only call site of barkimedes/go-deepcopy, so the module is also removed from go.mod / go.sum.