### PR TITLE
perf(term,rule): Pre-allocate Vars and fast-path SubstBinding

### DIFF
--- a/rule/fact.go
+++ b/rule/fact.go
@@ -160,12 +160,17 @@ func (f *Fact) Subst(b *term.Binding) *Fact {
 }
 
 func (f *Fact) Vars() []*term.Variable {
-	var vars []*term.Variable
-
+	total := 0
 	for _, a := range f.Args {
-		vars = append(vars, term.Vars(a)...)
+		total += term.VarCount(a)
 	}
-
+	if total == 0 {
+		return nil
+	}
+	vars := make([]*term.Variable, 0, total)
+	for _, a := range f.Args {
+		vars = term.AppendVars(vars, a)
+	}
 	return vars
 }
 
@@ -214,12 +219,21 @@ func (f Facts) Swap(i, j int) {
 }
 
 func (f Facts) Vars() []*term.Variable {
-	var vars []*term.Variable
-
+	total := 0
 	for _, fact := range f {
-		vars = append(vars, fact.Vars()...)
+		for _, arg := range fact.Args {
+			total += term.VarCount(arg)
+		}
 	}
-
+	if total == 0 {
+		return nil
+	}
+	vars := make([]*term.Variable, 0, total)
+	for _, fact := range f {
+		for _, arg := range fact.Args {
+			vars = term.AppendVars(vars, arg)
+		}
+	}
 	return vars
 }
 

--- a/term/term.go
+++ b/term/term.go
@@ -520,25 +520,84 @@ type WeakTerm struct {
 	Args  []WeakTerm `json:"args,omitempty"`
 }
 
-func Vars(t Term) []*Variable {
-	var vars []*Variable
+// VarCount returns the number of variables contained in t.
+// Cheaper than len(Vars(t)) because it avoids allocating the slice.
+func VarCount(t Term) int {
+	return countVars(t)
+}
 
+// AppendVars appends the variables found in t to vars and returns the
+// resulting slice. Useful when collecting variables from several terms
+// into a single pre-sized slice.
+func AppendVars(vars []*Variable, t Term) []*Variable {
+	return appendVars(vars, t)
+}
+
+func countVars(t Term) int {
+	if t == nil {
+		return 0
+	}
 	switch t.GetType() {
 	case FunctionType:
-		t := Must(AsFunction(t))
-		for _, arg := range t.Args {
-			vars = append(vars, Vars(arg)...)
+		f := Must(AsFunction(t))
+		total := 0
+		for _, arg := range f.Args {
+			total += countVars(arg)
+		}
+		return total
+	case VariableType:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func appendVars(vars []*Variable, t Term) []*Variable {
+	if t == nil {
+		return vars
+	}
+	switch t.GetType() {
+	case FunctionType:
+		f := Must(AsFunction(t))
+		for _, arg := range f.Args {
+			vars = appendVars(vars, arg)
 		}
 	case VariableType:
-		v := Must(AsVariable(t))
-		vars = append(vars, v)
+		vars = append(vars, Must(AsVariable(t)))
 	}
-
 	return vars
 }
 
+// Vars returns the variables contained in t. The result slice is
+// pre-sized via VarCount so the recursive walk does not reallocate.
+func Vars(t Term) []*Variable {
+	count := countVars(t)
+	if count == 0 {
+		return nil
+	}
+	vars := make([]*Variable, 0, count)
+	return appendVars(vars, t)
+}
+
+// occurs reports whether v appears in t. Used by the unification
+// occurs-check; short-circuits without allocating, unlike
+// slices.Contains(Vars(t), v).
+func occurs(v *Variable, t Term) bool {
+	switch n := t.(type) {
+	case *Variable:
+		return v == n
+	case *Function:
+		for _, arg := range n.Args {
+			if occurs(v, arg) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func IsGround(t Term) bool {
-	return len(Vars(t)) == 0
+	return VarCount(t) == 0
 }
 
 // Substitute variable x in g with t.
@@ -570,8 +629,25 @@ func Subst(x Variable, t, g Term) Term {
 	return g
 }
 
-// Apply binding b to term g.
+// Apply binding b to term g. When every key in b is a Variable (the
+// common case), uses a single recursive walk that replaces variables
+// from a map lookup and returns the original subtree unchanged when
+// no replacements fire. Otherwise falls back to the generic
+// per-binding Replace loop.
+//
+// The fast path does not follow chains: for b = {x->y, y->1} and g = x,
+// the result is y, not 1. Callers that need chained resolution should
+// call b.ComputeFixpoint() before SubstBinding. The fallback path is
+// also chain-blind in the sense that it depends on map iteration order,
+// so its old behaviour on chained bindings was non-deterministic.
 func SubstBinding(b *Binding, g Term) Term {
+	if b == nil || b.Empty() {
+		return g
+	}
+	if bindingAllVariables(b) {
+		return substVars(b, g)
+	}
+
 	next := g
 
 	b.Iterate(func(x, t Term) bool {
@@ -581,6 +657,55 @@ func SubstBinding(b *Binding, g Term) Term {
 	})
 
 	return next
+}
+
+// substVars is the fast path for SubstBinding when every key in b is a
+// Variable: a single recursive walk that returns the original Function
+// subtree when none of its args changed.
+func substVars(b *Binding, g Term) Term {
+	switch t := g.(type) {
+	case *Variable:
+		if v, ok := b.Get(t); ok {
+			return v
+		}
+		return t
+	case *Function:
+		var modified bool
+		var args []Term
+
+		for i, arg := range t.Args {
+			sub := substVars(b, arg)
+			if sub == arg {
+				continue
+			}
+			if !modified {
+				args = make([]Term, len(t.Args))
+				copy(args, t.Args)
+				modified = true
+			}
+			args[i] = sub
+		}
+
+		if !modified {
+			return t
+		}
+
+		return NewFunction(t.Name, args)
+	default:
+		return g
+	}
+}
+
+func bindingAllVariables(b *Binding) bool {
+	all := true
+	b.Iterate(func(k, _ Term) bool {
+		if _, ok := k.(*Variable); !ok {
+			all = false
+			return false
+		}
+		return true
+	})
+	return all
 }
 
 func (c *Constant[T]) Unify(t Term) (*Binding, error) {
@@ -743,7 +868,7 @@ func unify(a1, a2 Term, b *Binding) error {
 	case t1Type == VariableType:
 		v := Must(AsVariable(a1))
 
-		if slices.Contains(Vars(a2), v) {
+		if occurs(v, a2) {
 			// return &UnificationError{a1, a2, "occurs check failed"}
 			return ErrOccursCheckFailed
 		}

--- a/term/term_test.go
+++ b/term/term_test.go
@@ -366,3 +366,150 @@ func TestEvaluate(t *testing.T) {
 		}
 	}
 }
+
+// Vars walks f(a, g(b, a), c) and returns variables in left-to-right
+// order with duplicates preserved. Pin this so the prealloc rewrite
+// can't silently reorder.
+func TestVarsOrder(t *testing.T) {
+	t.Parallel()
+
+	a := term.NewVariable("a")
+	b := term.NewVariable("b")
+	c := term.NewVariable("c")
+	tt := term.NewFunction("f", []term.Term{
+		a,
+		term.NewFunction("g", []term.Term{b, a}),
+		c,
+	})
+
+	got := term.Vars(tt)
+	want := []*term.Variable{a, b, a, c}
+	if len(got) != len(want) {
+		t.Fatalf("Vars returned %d variables; want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Vars[%d] = %q; want %q", i, got[i].Name, want[i].Name)
+		}
+	}
+}
+
+func TestVarCountAndIsGround(t *testing.T) {
+	t.Parallel()
+
+	a := term.NewVariable("a")
+	b := term.NewVariable("b")
+	c1 := term.NewConstant(1)
+
+	ground := term.NewFunction("h", []term.Term{c1, c1})
+	open := term.NewFunction("f", []term.Term{a, term.NewFunction("g", []term.Term{b, a}), c1})
+
+	if term.VarCount(ground) != 0 {
+		t.Errorf("VarCount(ground) = %d; want 0", term.VarCount(ground))
+	}
+	if !term.IsGround(ground) {
+		t.Errorf("IsGround(ground) = false; want true")
+	}
+
+	if term.VarCount(open) != len(term.Vars(open)) {
+		t.Errorf("VarCount(open) = %d; want %d (matches len(Vars))",
+			term.VarCount(open), len(term.Vars(open)))
+	}
+	if term.IsGround(open) {
+		t.Errorf("IsGround(open) = true; want false")
+	}
+}
+
+// SubstBinding's all-variable-keys fast path is now deliberately
+// chain-blind: {x->y, y->1} applied to x returns y, not 1. Callers that
+// need chain resolution must call ComputeFixpoint first. These cases
+// pin the contract so future "fixes" don't silently reintroduce
+// chain-following.
+func TestSubstBindingFastPath(t *testing.T) {
+	t.Parallel()
+
+	x := term.NewVariable("x")
+	y := term.NewVariable("y")
+	z := term.NewVariable("z")
+	one := term.NewConstant(1)
+
+	t.Run("empty binding returns g unchanged", func(t *testing.T) {
+		t.Parallel()
+		empty := term.NewBinding()
+		got := term.SubstBinding(empty, x)
+		if got != term.Term(x) {
+			t.Errorf("SubstBinding(empty, x) = %v; want x (identity)", got)
+		}
+	})
+
+	t.Run("single var to constant at top level", func(t *testing.T) {
+		t.Parallel()
+		b := term.NewBinding()
+		b.Set(x, one)
+		got := term.SubstBinding(b, x)
+		if !got.Equal(one) {
+			t.Errorf("SubstBinding({x->1}, x) = %v; want 1", got)
+		}
+	})
+
+	t.Run("nested function substitution returns rebuilt function", func(t *testing.T) {
+		t.Parallel()
+		b := term.NewBinding()
+		b.Set(x, one)
+		input := term.NewFunction("f", []term.Term{x, y})
+		got := term.SubstBinding(b, input)
+		want := term.NewFunction("f", []term.Term{one, y})
+		if !got.Equal(want) {
+			t.Errorf("SubstBinding({x->1}, f(x,y)) = %v; want %v", got, want)
+		}
+	})
+
+	t.Run("unchanged subtree (no var matches) returns identity", func(t *testing.T) {
+		t.Parallel()
+		b := term.NewBinding()
+		b.Set(z, one)
+		input := term.NewFunction("f", []term.Term{x, y})
+		got := term.SubstBinding(b, input)
+		if got != term.Term(input) {
+			t.Errorf("SubstBinding({z->1}, f(x,y)) should return the original pointer; got %v", got)
+		}
+	})
+
+	t.Run("chained binding without fixpoint returns intermediate", func(t *testing.T) {
+		t.Parallel()
+		// {x->y, y->1} applied to x: fast path does not follow chains.
+		b := term.NewBinding()
+		b.Set(x, y)
+		b.Set(y, one)
+		got := term.SubstBinding(b, x)
+		if !got.Equal(y) {
+			t.Errorf("SubstBinding({x->y, y->1}, x) = %v; want y (fast path is chain-blind)", got)
+		}
+	})
+
+	t.Run("chained binding with ComputeFixpoint resolves", func(t *testing.T) {
+		t.Parallel()
+		b := term.NewBinding()
+		b.Set(x, y)
+		b.Set(y, one)
+		fp := b.ComputeFixpoint()
+		got := term.SubstBinding(fp, x)
+		if !got.Equal(one) {
+			t.Errorf("SubstBinding(ComputeFixpoint({x->y, y->1}), x) = %v; want 1", got)
+		}
+	})
+
+	t.Run("non-variable key falls back to per-binding Replace", func(t *testing.T) {
+		t.Parallel()
+		// Map a function term to a variable; the all-variables fast
+		// path must be skipped so Replace can match the function.
+		fxy := term.NewFunction("f", []term.Term{x, y})
+		b := term.NewBinding()
+		b.Set(fxy, z)
+		got := term.SubstBinding(b, term.NewFunction("g", []term.Term{fxy}))
+		want := term.NewFunction("g", []term.Term{z})
+		if !got.Equal(want) {
+			t.Errorf("SubstBinding({f(x,y)->z}, g(f(x,y))) = %v; want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
Vars allocated and grew its result slice as it recursed. It now walks twice, once to count and once to fill a pre-sized slice. New exported helpers VarCount and AppendVars let callers like Fact.Vars, Facts.Vars, and IsGround sum sizes across multiple terms before allocating once.

unify's occurs check no longer materialises Vars(a2). It calls a direct walker occurs(v, a2) that short-circuits on hit.

SubstBinding grows an all-variable-keys fast path. When every key is a *Variable, substVars does a single recursive walk with a map lookup, returning the original subtree pointer when no replacements fire. The slow per-binding Replace loop is kept as fallback for bindings with non-Variable keys.

The fast path is deliberately chain-blind: {x->y, y->1} substituted into x returns y, not 1. Callers needing chain resolution should call b.ComputeFixpoint() first (parseLetBlock already does).

Tests:

- TestVarsOrder pins left-to-right order with duplicates preserved.
- TestVarCountAndIsGround pins the cheap helpers against len(Vars).
- TestSubstBindingFastPath covers empty binding, top-level and nested substitution, identity return on unchanged subtrees, the chain-blind contract with and without ComputeFixpoint, and the non-Variable-key fallback.