### PR TITLE
revert(data,term): Hash collisions and symmetric Binding.Equal (#69)

### DIFF
--- a/data/hashmap.go
+++ b/data/hashmap.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
-	"reflect"
 	"sort"
 	"strings"
 )
@@ -32,7 +31,7 @@ type Hasher interface {
 }
 
 type HashMap[K, V any] struct {
-	m map[uint64][]Entry[K, V]
+	m map[uint64]Entry[K, V]
 	h hash.Hash64
 }
 
@@ -41,36 +40,9 @@ type Entry[K, V any] struct {
 	Value V
 }
 
-// equaler[K] is the contract used to disambiguate two K values that
-// land in the same hash bucket. It must be a symmetric equivalence
-// relation: a.Equal(b) == b.Equal(a). Asymmetric implementations
-// (e.g. a subset test) will silently dedupe distinct keys when their
-// hashes happen to collide.
-type equaler[K any] interface {
-	Equal(K) bool
-}
-
-// keysEqual compares two K values for in-bucket equality, in this order:
-//  1. K's own Equal[K] method, if implemented.
-//  2. Go's == operator, if K is comparable (e.g. pointers, structs of
-//     comparables).
-//  3. reflect.DeepEqual as a last resort, for non-comparable composite
-//     types like []T or map[K]V. This path is rare in production —
-//     the codebase uses pointer or Equaler keys — but is required by
-//     HashSet[[]int] in tests.
-func keysEqual[K any](a, b K) bool {
-	if eq, ok := any(a).(equaler[K]); ok {
-		return eq.Equal(b)
-	}
-	if t := reflect.TypeOf(a); t != nil && t.Comparable() {
-		return any(a) == any(b)
-	}
-	return reflect.DeepEqual(a, b)
-}
-
 func NewHashMap[K, V any]() *HashMap[K, V] {
 	return &HashMap[K, V]{
-		m: make(map[uint64][]Entry[K, V]),
+		m: make(map[uint64]Entry[K, V]),
 		h: fnv.New64a(),
 	}
 }
@@ -94,62 +66,28 @@ func (h *HashMap[K, V]) hash(k K) uint64 {
 }
 
 func (h *HashMap[K, V]) Get(k K) (V, bool) {
-	var zero V
-	bucket, ok := h.m[h.hash(k)]
-	if !ok {
-		return zero, false
-	}
-	for _, entry := range bucket {
-		if keysEqual(entry.Key, k) {
-			return entry.Value, true
-		}
-	}
-	return zero, false
+	entry, ok := h.m[h.hash(k)]
+
+	return entry.Value, ok
 }
 
 func (h *HashMap[K, V]) Set(k K, v V) {
-	hash := h.hash(k)
-	bucket := h.m[hash]
-	for i, entry := range bucket {
-		if keysEqual(entry.Key, k) {
-			bucket[i].Value = v
-			h.m[hash] = bucket
-			return
-		}
-	}
-	h.m[hash] = append(bucket, Entry[K, V]{k, v})
+	h.m[h.hash(k)] = Entry[K, V]{k, v}
 }
 
 func (h *HashMap[K, V]) Remove(k K) {
-	hash := h.hash(k)
-	bucket, ok := h.m[hash]
-	if !ok {
-		return
-	}
-	for i, entry := range bucket {
-		if keysEqual(entry.Key, k) {
-			bucket = append(bucket[:i], bucket[i+1:]...)
-			if len(bucket) == 0 {
-				delete(h.m, hash)
-			} else {
-				h.m[hash] = bucket
-			}
-			return
-		}
-	}
+	delete(h.m, h.hash(k))
 }
 
 func (h *HashMap[K, V]) Empty() bool {
-	return h.Size() == 0
+	return len(h.m) == 0
 }
 
 func (h *HashMap[K, V]) Keys() []K {
 	keys := make([]K, 0, h.Size())
 
-	for _, bucket := range h.m {
-		for _, entry := range bucket {
-			keys = append(keys, entry.Key)
-		}
+	for _, entry := range h.m {
+		keys = append(keys, entry.Key)
 	}
 
 	return keys
@@ -158,33 +96,25 @@ func (h *HashMap[K, V]) Keys() []K {
 func (h *HashMap[K, V]) Values() []V {
 	values := make([]V, 0, h.Size())
 
-	for _, bucket := range h.m {
-		for _, entry := range bucket {
-			values = append(values, entry.Value)
-		}
+	for _, entry := range h.m {
+		values = append(values, entry.Value)
 	}
 
 	return values
 }
 
 func (h *HashMap[K, V]) Size() int {
-	n := 0
-	for _, bucket := range h.m {
-		n += len(bucket)
-	}
-	return n
+	return len(h.m)
 }
 
 func (h *HashMap[K, V]) String() string {
 	s := "HashMap["
 
-	for _, bucket := range h.m {
-		for _, entry := range bucket {
-			s += fmt.Sprintf("%v", entry.Key)
-			s += ":"
-			s += fmt.Sprintf("%v", entry.Value)
-			s += " "
-		}
+	for _, entry := range h.m {
+		s += fmt.Sprintf("%v", entry.Key)
+		s += ":"
+		s += fmt.Sprintf("%v", entry.Value)
+		s += " "
 	}
 	s = strings.TrimSuffix(s, " ")
 
@@ -192,11 +122,9 @@ func (h *HashMap[K, V]) String() string {
 }
 
 func (h *HashMap[K, V]) Iterate(f func(K, V) bool) {
-	for _, bucket := range h.m {
-		for _, entry := range bucket {
-			if !f(entry.Key, entry.Value) {
-				return
-			}
+	for _, entry := range h.m {
+		if !f(entry.Key, entry.Value) {
+			break
 		}
 	}
 }
@@ -213,24 +141,20 @@ func (h *HashMap[K, V]) IterateSorted(f func(K, V) bool) {
 	})
 
 	for _, k := range keys {
-		for _, entry := range h.m[k] {
-			if !f(entry.Key, entry.Value) {
-				return
-			}
+		entry := h.m[k]
+		if !f(entry.Key, entry.Value) {
+			break
 		}
 	}
 }
 
 func (h *HashMap[K, V]) Clone() *HashMap[K, V] {
 	c := &HashMap[K, V]{
-		m: make(map[uint64][]Entry[K, V], len(h.m)),
-		h: fnv.New64a(),
+		m: make(map[uint64]Entry[K, V], len(h.m)),
 	}
 
-	for k, bucket := range h.m {
-		copied := make([]Entry[K, V], len(bucket))
-		copy(copied, bucket)
-		c.m[k] = copied
+	for k, v := range h.m {
+		c.m[k] = v
 	}
 
 	return c
@@ -239,10 +163,9 @@ func (h *HashMap[K, V]) Clone() *HashMap[K, V] {
 func (h *HashMap[K, V]) Extend(hp *HashMap[K, V]) *HashMap[K, V] {
 	u := h.Clone()
 
-	hp.Iterate(func(k K, v V) bool {
-		u.Set(k, v)
-		return true
-	})
+	for k, v := range hp.m {
+		u.m[k] = v
+	}
 
 	return u
 }

--- a/data/hashmap_test.go
+++ b/data/hashmap_test.go
@@ -52,151 +52,15 @@ func TestHashMap(t *testing.T) {
 	}
 }
 
-// collidingKey forces a hash collision between distinct values via the
-// HashMap's Hasher interface. Without bucket-per-hash storage, the second
-// Set would overwrite the first; both entries would resolve to the same
-// pair on subsequent Get calls.
-type collidingKey struct {
-	id     int
-	bucket uint64
-}
-
-func (k collidingKey) Hash() uint64 { return k.bucket }
-
-func (k collidingKey) Equal(other collidingKey) bool { return k.id == other.id }
-
-func TestForcedCollisionDoesNotOverwrite(t *testing.T) {
+func TestCollision(t *testing.T) {
 	t.Parallel()
 
-	h := data.NewHashMap[collidingKey, string]()
+	h := data.NewHashMap[string, int]()
 
-	k1 := collidingKey{id: 1, bucket: 42}
-	k2 := collidingKey{id: 2, bucket: 42}
-	k3 := collidingKey{id: 3, bucket: 42}
+	h.Set("creamwove", 1)
+	h.Set("quists", 2)
 
-	h.Set(k1, "one")
-	h.Set(k2, "two")
-	h.Set(k3, "three")
-
-	if h.Size() != 3 {
-		t.Fatalf("Size() = %d; want 3 (all three colliding keys stored)", h.Size())
-	}
-
-	for _, tc := range []struct {
-		k    collidingKey
-		want string
-	}{
-		{k1, "one"},
-		{k2, "two"},
-		{k3, "three"},
-	} {
-		got, ok := h.Get(tc.k)
-		if !ok {
-			t.Errorf("Get(%+v) = (_, false); want (%q, true)", tc.k, tc.want)
-			continue
-		}
-		if got != tc.want {
-			t.Errorf("Get(%+v) = %q; want %q", tc.k, got, tc.want)
-		}
-	}
-
-	// Update of one colliding key must not corrupt the others.
-	h.Set(k2, "two-updated")
-	if got, _ := h.Get(k2); got != "two-updated" {
-		t.Errorf("Get(k2 after Set) = %q; want %q", got, "two-updated")
-	}
-	if got, _ := h.Get(k1); got != "one" {
-		t.Errorf("Get(k1 after k2 update) = %q; want %q (sibling corrupted)", got, "one")
-	}
-	if got, _ := h.Get(k3); got != "three" {
-		t.Errorf("Get(k3 after k2 update) = %q; want %q (sibling corrupted)", got, "three")
-	}
-
-	// Remove must not affect siblings.
-	h.Remove(k2)
-	if _, ok := h.Get(k2); ok {
-		t.Error("Get(k2 after Remove) returned (true); want (false)")
-	}
-	if got, _ := h.Get(k1); got != "one" {
-		t.Errorf("Get(k1 after Remove(k2)) = %q; want %q", got, "one")
-	}
-	if got, _ := h.Get(k3); got != "three" {
-		t.Errorf("Get(k3 after Remove(k2)) = %q; want %q", got, "three")
-	}
 	if h.Size() != 2 {
-		t.Errorf("Size() after Remove = %d; want 2", h.Size())
-	}
-}
-
-func TestForcedCollisionIterateKeysValues(t *testing.T) {
-	t.Parallel()
-
-	h := data.NewHashMap[collidingKey, string]()
-	k1 := collidingKey{id: 1, bucket: 7}
-	k2 := collidingKey{id: 2, bucket: 7}
-	k3 := collidingKey{id: 3, bucket: 7}
-	h.Set(k1, "one")
-	h.Set(k2, "two")
-	h.Set(k3, "three")
-
-	// Iterate must visit every colliding entry exactly once.
-	visited := map[int]string{}
-	h.Iterate(func(k collidingKey, v string) bool {
-		if _, dup := visited[k.id]; dup {
-			t.Errorf("Iterate revisited key id=%d", k.id)
-		}
-		visited[k.id] = v
-		return true
-	})
-	for _, want := range []struct {
-		id int
-		v  string
-	}{{1, "one"}, {2, "two"}, {3, "three"}} {
-		if visited[want.id] != want.v {
-			t.Errorf("Iterate missed key id=%d (got %q, want %q)", want.id, visited[want.id], want.v)
-		}
-	}
-
-	// Early return from Iterate must stop the walk.
-	count := 0
-	h.Iterate(func(_ collidingKey, _ string) bool {
-		count++
-		return false
-	})
-	if count != 1 {
-		t.Errorf("Iterate visit count with early return = %d; want 1", count)
-	}
-
-	// Keys and Values must return all colliding entries.
-	if got := len(h.Keys()); got != 3 {
-		t.Errorf("len(Keys) = %d; want 3", got)
-	}
-	if got := len(h.Values()); got != 3 {
-		t.Errorf("len(Values) = %d; want 3", got)
-	}
-}
-
-func TestForcedCollisionCloneIsIndependent(t *testing.T) {
-	t.Parallel()
-
-	h := data.NewHashMap[collidingKey, string]()
-	k1 := collidingKey{id: 1, bucket: 9}
-	k2 := collidingKey{id: 2, bucket: 9}
-	h.Set(k1, "one")
-	h.Set(k2, "two")
-
-	c := h.Clone()
-
-	// Mutating the clone must not touch the original (and vice versa).
-	c.Set(k1, "one-clone")
-	if got, _ := h.Get(k1); got != "one" {
-		t.Errorf("Clone shares bucket storage: original.Get(k1) = %q after clone.Set; want %q", got, "one")
-	}
-	c.Remove(k2)
-	if _, ok := h.Get(k2); !ok {
-		t.Errorf("Clone shares bucket storage: original.Get(k2) missing after clone.Remove")
-	}
-	if h.Size() != 2 {
-		t.Errorf("original.Size after clone mutation = %d; want 2", h.Size())
+		t.Errorf("%v should have size of %d, got %d", h, 2, h.Size())
 	}
 }

--- a/data/hashset.go
+++ b/data/hashset.go
@@ -23,13 +23,6 @@ import (
 	"strings"
 )
 
-// HashSet embeds HashMap by value. Method calls on HashSet receive a
-// HashSet value, so writes through h.m.Set/Remove operate on a copy of
-// the embedded HashMap struct — but the underlying `m` map field is a
-// reference type, so map mutations propagate to the original. Any
-// future addition of a non-reference field to HashMap (an int counter,
-// a fixed-size buffer, etc.) would silently break HashSet writes.
-// If such a field is needed, change the embedding to *HashMap.
 type HashSet[T any] struct {
 	m HashMap[T, struct{}]
 }
@@ -75,20 +68,21 @@ func (h HashSet[T]) Values() []T {
 func (h HashSet[T]) String() string {
 	s := "HashSet["
 
-	h.m.Iterate(func(k T, _ struct{}) bool {
-		s += fmt.Sprintf("%v", k)
+	for _, entry := range h.m.m {
+		s += fmt.Sprintf("%v", entry.Key)
 		s += " "
-		return true
-	})
+	}
 	s = strings.TrimSuffix(s, " ")
 
 	return s + "]"
 }
 
 func (h HashSet[T]) Iterate(f func(T) bool) {
-	h.m.Iterate(func(k T, _ struct{}) bool {
-		return f(k)
-	})
+	for _, entry := range h.m.m {
+		if !f(entry.Key) {
+			break
+		}
+	}
 }
 
 func (h HashSet[T]) Union(h1 *HashSet[T]) *HashSet[T] {

--- a/term/binding.go
+++ b/term/binding.go
@@ -68,31 +68,22 @@ func (b *Binding) ComputeFixpoint() *Binding {
 	return c
 }
 
-// Equal reports whether b and bp bind the same keys to the same values.
-// It is symmetric: equal sizes plus the receiver's keys all matching the
-// argument's values implies the reverse direction holds too.
 func (b *Binding) Equal(bp *Binding) bool {
-	if bp == nil {
-		return b == nil || b.Size() == 0
-	}
-	if b == nil {
-		return bp.Size() == 0
-	}
-	if b.Size() != bp.Size() {
-		return false
-	}
-
 	equal := true
+
 	b.Iterate(func(k, v Term) bool {
 		if vp, ok := bp.Get(k); ok {
 			if !v.Equal(vp) {
 				equal = false
+
 				return false
 			}
 		} else {
 			equal = false
+
 			return false
 		}
+
 		return true
 	})
 

--- a/term/binding_test.go
+++ b/term/binding_test.go
@@ -99,38 +99,3 @@ func TestBindingHashSet(t *testing.T) {
 		t.Errorf("Expected 2 bindings, got %d", h.Size())
 	}
 }
-
-// Binding.Equal previously walked only the receiver, so a strict subset
-// {x->1} would compare equal to its superset {x->1, y->2} in one
-// direction. Equal must be a true equivalence relation because callers
-// like data.HashMap use it to dedupe colliding keys.
-func TestBindingEqualIsSymmetric(t *testing.T) {
-	t.Parallel()
-
-	small := term.BindingFromMap(map[term.Term]term.Term{
-		term.NewVariable("x"): term.NewConstant(1),
-	})
-	large := term.BindingFromMap(map[term.Term]term.Term{
-		term.NewVariable("x"): term.NewConstant(1),
-		term.NewVariable("y"): term.NewConstant(2),
-	})
-
-	if small.Equal(large) {
-		t.Error("small.Equal(large) should be false (sizes differ)")
-	}
-	if large.Equal(small) {
-		t.Error("large.Equal(small) should be false (sizes differ)")
-	}
-
-	// And the symmetric positive case still holds.
-	other := term.BindingFromMap(map[term.Term]term.Term{
-		term.NewVariable("y"): term.NewConstant(2),
-		term.NewVariable("x"): term.NewConstant(1),
-	})
-	if !large.Equal(other) {
-		t.Error("large.Equal(other) should be true (same keys, same values)")
-	}
-	if !other.Equal(large) {
-		t.Error("other.Equal(large) should be true (symmetry)")
-	}
-}


### PR DESCRIPTION
#69 switched HashMap to bucket-per-hash storage and tightened Binding.Equal to a symmetric equivalence. Both are correct in isolation but together they regress wireguard server.log monitoring from ~6000 events in 15s to ~130 events in 60s. The cause is allocation pressure in HashMap.Set and HashMap.Clone, called per match in monitor.conflictSet via Binding.Extend, combined with the loss of an implicit dedup the conflict-set search depended on.

Alternative designs investigated:

- O(1) size counter on HashMap.
- Sidecar overflow map (one Entry inline plus a per-hash overflow).
- Open-addressed flat slot table with linear probing.
- Lazy initialisation of the backing store on first Set.
- Reverting only the Binding.Equal change.

Each variant beat #69 on microbenchmarks but still stalled the wireguard run at ~130 events. The root cause is that Binding cannot be alloc-free per Set without term interning: equal-valued Term keys must share pointers so map[K]V semantics align with logical equality. Interning is the upcoming foundation work; the collision-correctness and Equal-symmetry fixes belong with it.

Refs: a25586b862c48c2f320ca96de6db9618afb6972e