### PR TITLE
perf(monitor): Index the conflict set and cap duplicate expansion

### DIFF
--- a/monitor/conflict_set.go
+++ b/monitor/conflict_set.go
@@ -288,7 +288,7 @@ func conflictSetSingle[T Unifier[T]](items []T, p T, indexable func(T) bool, nam
 	return result
 }
 
-func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name func(T) string, args func(T) []term.Term) *bindingSet {
+func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name func(T) string, args func(T) []term.Term, hash func(T) uint64, equal func(a, b T) bool) *bindingSet {
 	log.Debugf("conflictSet( items=%d, body=%d )\n", len(items), len(body))
 
 	if len(body) == 1 {
@@ -301,9 +301,83 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 	}
 	needsByKey, needAllIndices := collectIndexNeeds(body, indexable, name, constraintsByBody)
 
-	// Index items by name+arity and per-argument constants.
+	// Count how many body slots reference each (name, arity) key. The DFS
+	// can never consume more instances of a key than there are body slots
+	// requesting it, so any multiset multiplicity beyond that count is
+	// wasted iteration. We cap each duplicate group at min(count, slots).
+	bodySlotCount := make(map[conflictKey]int, len(needsByKey))
+	for i, p := range body {
+		if !indexable(p) {
+			continue
+		}
+		k := conflictKey{name: name(p), arity: constraintsByBody[i].arity}
+		bodySlotCount[k]++
+	}
+
+	// Build a virtual items slice that drops duplicate instances beyond the
+	// body slot cap for their (name, arity) key. Items that aren't
+	// indexable, or whose key isn't referenced by any body pattern, pass
+	// through unchanged so the !indexable(p) fallback path still works.
+	var virtualItems []T
+	if hash != nil && equal != nil {
+		virtualItems = make([]T, 0, len(items))
+		// seenByKey: per (name, arity) key, hash -> list of virtual indices
+		// for the unique items already admitted under this key. New items
+		// hash-match against this; equal-match decides duplicate.
+		seenByKey := make(map[conflictKey]map[uint64][]int)
+		// dupCount[vIdx]: how many copies of the unique fact first seen at
+		// vIdx have been admitted so far. Capped at bodySlotCount[key].
+		dupCount := make(map[int]int)
+
+		for _, item := range items {
+			if !indexable(item) {
+				virtualItems = append(virtualItems, item)
+				continue
+			}
+			key := conflictKey{name: name(item), arity: len(args(item))}
+			slotCap := bodySlotCount[key]
+			if slotCap == 0 {
+				// No body slot consumes this key. Pass through so the
+				// needAllIndices fallback can still see it.
+				virtualItems = append(virtualItems, item)
+				continue
+			}
+			h := hash(item)
+			bucketSeen := seenByKey[key]
+			if bucketSeen == nil {
+				bucketSeen = make(map[uint64][]int)
+				seenByKey[key] = bucketSeen
+			}
+			// Check whether this item duplicates an already-admitted unique.
+			matched := -1
+			for _, vIdx := range bucketSeen[h] {
+				if equal(virtualItems[vIdx], item) {
+					matched = vIdx
+					break
+				}
+			}
+			if matched >= 0 {
+				if dupCount[matched] >= slotCap {
+					// Already at slot cap: drop further copies.
+					continue
+				}
+				dupCount[matched]++
+				virtualItems = append(virtualItems, item)
+				continue
+			}
+			// New unique fact.
+			vNew := len(virtualItems)
+			virtualItems = append(virtualItems, item)
+			bucketSeen[h] = append(bucketSeen[h], vNew)
+			dupCount[vNew] = 1
+		}
+	} else {
+		virtualItems = items
+	}
+
+	// Index virtual items by name+arity and per-argument constants.
 	itemsByKey := make(map[conflictKey]*itemBucket, len(needsByKey))
-	for i, item := range items {
+	for i, item := range virtualItems {
 		if !indexable(item) {
 			continue
 		}
@@ -341,8 +415,8 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 				posMap = make(map[uint64][]int)
 				bucket.constIndex[pos] = posMap
 			}
-			hash := arg.Hash()
-			posMap[hash] = append(posMap[hash], i)
+			h := arg.Hash()
+			posMap[h] = append(posMap[h], i)
 		}
 	}
 
@@ -353,8 +427,8 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 
 	var allIndices []int
 	if needAllIndices {
-		allIndices = make([]int, len(items))
-		for j := range items {
+		allIndices = make([]int, len(virtualItems))
+		for j := range virtualItems {
 			allIndices[j] = j
 		}
 	}
@@ -390,7 +464,7 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 
 		filtered := make([]int, 0, len(candIndices))
 		for _, idx := range candIndices {
-			fArgs := args(items[idx])
+			fArgs := args(virtualItems[idx])
 			if constraints.matchesArgs(fArgs) {
 				filtered = append(filtered, idx)
 			}
@@ -404,11 +478,12 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 
 	result := newBindingSet()
 
-	// Track which items from the original items slice have been used.
-	// This ensures multiset semantics s.t. each fact can only be consumed once.
+	// Track which virtual items have been used in the current DFS path.
+	// This ensures multiset semantics s.t. each (possibly deduped+capped)
+	// virtual instance can only be consumed once per binding path.
 	// Use a binding trail (mark/unwind) so the DFS reuses one mutable binding
 	// instead of cloning at every branch.
-	usedItems := make([]bool, len(items))
+	usedItems := make([]bool, len(virtualItems))
 	trail := term.NewBindingTrail()
 
 	var dfs func(pos int, b *term.Binding)
@@ -425,12 +500,12 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 		psArgs := args(ps)
 
 		for _, itemIdx := range prefilter[idx] {
-			// Skip if this fact has already been used in this binding path
+			// Skip if this virtual item has already been used in this binding path
 			if usedItems[itemIdx] {
 				continue
 			}
 
-			f := items[itemIdx]
+			f := virtualItems[itemIdx]
 			fArgs := args(f)
 			if len(psArgs) == len(fArgs) {
 				skip := false
@@ -464,17 +539,23 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 }
 
 // conflictSetFacts matches a sequence of fact patterns against a multiset of facts.
-// It builds a per-predicate local index and uses DFS with early filtering by constants.
+// It builds a per-predicate local index, deduplicates identical facts up to the
+// per-predicate body slot count, and uses DFS with early filtering by constants.
 func conflictSetFacts(facts []*rule.Fact, body []*rule.Fact) *bindingSet {
 	return conflictSet(facts, body,
 		func(_ *rule.Fact) bool { return true },
 		func(f *rule.Fact) string { return f.Name },
 		func(f *rule.Fact) []term.Term { return f.Args },
+		func(f *rule.Fact) uint64 { return f.Hash() },
+		func(a, b *rule.Fact) bool { return a.Equal(b) },
 	)
 }
 
 // conflictSetTerms matches a sequence of term patterns against a set of seen terms.
 // It builds a local index by function name and orders patterns by selectivity.
+// Seen terms are not deduplicated (passed nil hash/equal): the seen set is
+// already kept distinct upstream, so capping by body slot count would only
+// add overhead without removing any iteration.
 func conflictSetTerms(seen []term.Term, body []term.Term) *bindingSet {
 	return conflictSet(seen, body,
 		func(t term.Term) bool {
@@ -495,6 +576,8 @@ func conflictSetTerms(seen []term.Term, body []term.Term) *bindingSet {
 			}
 			return nil
 		},
+		nil,
+		nil,
 	)
 }
 

--- a/monitor/conflict_set.go
+++ b/monitor/conflict_set.go
@@ -23,19 +23,326 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/specmon/specmon/data"
 	"github.com/specmon/specmon/rule"
 	"github.com/specmon/specmon/term"
 )
 
-func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name func(T) string, args func(T) []term.Term) *data.HashSet[*term.Binding] {
+type conflictKey struct {
+	name  string
+	arity int
+}
+
+type itemBucket struct {
+	indices    []int
+	constIndex map[int]map[uint64][]int
+}
+
+type constPos struct {
+	pos  int
+	term term.Term
+	hash uint64
+}
+
+type formatConstraint struct {
+	minLen int
+	maxLen int
+	ok     bool
+}
+
+type argConstraints struct {
+	arity                int
+	constPositions       []constPos
+	disallowConstant     []bool
+	hasDisallowConstant  bool
+	formatConstraints    []formatConstraint
+	hasFormatConstraints bool
+}
+
+type keyIndexNeeds struct {
+	constPositions map[int]struct{}
+}
+
+func buildArgConstraints(pArgs []term.Term) argConstraints {
+	constraints := argConstraints{
+		arity: len(pArgs),
+	}
+	if len(pArgs) == 0 {
+		return constraints
+	}
+	constraints.disallowConstant = make([]bool, len(pArgs))
+	constraints.formatConstraints = make([]formatConstraint, len(pArgs))
+
+	for pos, arg := range pArgs {
+		if arg.GetType() == term.ConstantType {
+			constraints.constPositions = append(constraints.constPositions, constPos{
+				pos:  pos,
+				term: arg,
+				hash: arg.Hash(),
+			})
+		}
+
+		fn, err := term.AsFunction(arg)
+		if err != nil || fn == nil {
+			continue
+		}
+		if !fn.MayEvalToConstant() {
+			constraints.disallowConstant[pos] = true
+			constraints.hasDisallowConstant = true
+		}
+		if fc, ok := formatConstraintForCat(fn); ok {
+			constraints.formatConstraints[pos] = fc
+			constraints.hasFormatConstraints = true
+		}
+	}
+
+	return constraints
+}
+
+func collectIndexNeeds[T Unifier[T]](body []T, indexable func(T) bool, name func(T) string, constraintsByBody []argConstraints) (map[conflictKey]*keyIndexNeeds, bool) {
+	needsByKey := make(map[conflictKey]*keyIndexNeeds)
+	needAllIndices := false
+
+	for i, p := range body {
+		constraints := constraintsByBody[i]
+		if !indexable(p) {
+			needAllIndices = true
+			continue
+		}
+
+		key := conflictKey{name: name(p), arity: constraints.arity}
+		needs := needsByKey[key]
+		if needs == nil {
+			needs = &keyIndexNeeds{}
+			needsByKey[key] = needs
+		}
+
+		if len(constraints.constPositions) == 0 {
+			continue
+		}
+		if needs.constPositions == nil {
+			needs.constPositions = make(map[int]struct{}, len(constraints.constPositions))
+		}
+		for _, cp := range constraints.constPositions {
+			needs.constPositions[cp.pos] = struct{}{}
+		}
+	}
+
+	return needsByKey, needAllIndices
+}
+
+func (c argConstraints) matchesArgs(fArgs []term.Term) bool {
+	if len(fArgs) != c.arity {
+		return false
+	}
+	for _, cp := range c.constPositions {
+		if !cp.term.Equal(fArgs[cp.pos]) {
+			return false
+		}
+	}
+	if c.hasDisallowConstant {
+		for pos, disallow := range c.disallowConstant {
+			if disallow && fArgs[pos].GetType() == term.ConstantType {
+				return false
+			}
+		}
+	}
+	if c.hasFormatConstraints {
+		for pos, fc := range c.formatConstraints {
+			if !fc.ok {
+				continue
+			}
+			if fArgs[pos].GetType() != term.ConstantType {
+				continue
+			}
+			length, ok := constantByteLen(fArgs[pos])
+			if !ok {
+				continue
+			}
+			if length < fc.minLen {
+				return false
+			}
+			if fc.maxLen >= 0 && length > fc.maxLen {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func selectConstCandidates(constIndex map[int]map[uint64][]int, constPositions []constPos) []int {
+	var base []int
+	for _, cp := range constPositions {
+		posMap := constIndex[cp.pos]
+		if posMap == nil {
+			return nil
+		}
+		list := posMap[cp.hash]
+		if len(list) == 0 {
+			return nil
+		}
+		if base == nil || len(list) < len(base) {
+			base = list
+		}
+	}
+	return base
+}
+
+func formatConstraintForCat(fn *term.Function) (formatConstraint, bool) {
+	if fn.Name != term.CatFunctionName {
+		return formatConstraint{}, false
+	}
+	total := 0
+	for i, field := range fn.Args {
+		fieldFn, err := term.AsFunction(field)
+		if err != nil || fieldFn == nil {
+			return formatConstraint{}, false
+		}
+		length, known, variable := formatFieldLength(fieldFn)
+		switch {
+		case known && length >= 0:
+			total += length
+		case variable:
+			if i != len(fn.Args)-1 {
+				return formatConstraint{}, false
+			}
+			return formatConstraint{minLen: total, maxLen: -1, ok: true}, true
+		default:
+			return formatConstraint{}, false
+		}
+	}
+	return formatConstraint{minLen: total, maxLen: total, ok: true}, true
+}
+
+func formatFieldLength(field *term.Function) (int, bool, bool) {
+	if len(field.Args) == 2 {
+		length, err := term.AsInt(field.Args[1])
+		if err != nil || length < 0 {
+			return 0, false, false
+		}
+		return length, true, false
+	}
+	if len(field.Args) != 1 {
+		return 0, false, false
+	}
+	if length, ok := constantByteLen(field.Args[0]); ok {
+		return length, true, false
+	}
+	if _, err := term.AsVariable(field.Args[0]); err == nil {
+		return 0, false, true
+	}
+	return 0, false, false
+}
+
+func constantByteLen(t term.Term) (int, bool) {
+	switch c := t.(type) {
+	case *term.Constant[int]:
+		return 8, true
+	case *term.Constant[string]:
+		return len(c.Value), true
+	case *term.Constant[[]byte]:
+		return len(c.Value), true
+	default:
+		return 0, false
+	}
+}
+
+func conflictSetSingle[T Unifier[T]](items []T, p T, indexable func(T) bool, name func(T) string, args func(T) []term.Term) *bindingSet {
+	result := newBindingSet()
+
+	pArgs := args(p)
+	constraints := buildArgConstraints(pArgs)
+
+	indexedPattern := indexable(p)
+	pName := ""
+	if indexedPattern {
+		pName = name(p)
+	}
+
+	for _, item := range items {
+		itemArgs := args(item)
+
+		if indexedPattern {
+			if !indexable(item) || name(item) != pName || len(itemArgs) != len(pArgs) {
+				continue
+			}
+		}
+
+		// Only apply the argument prefilter when the pattern actually carries a
+		// constraint. matchesArgs gates on arity first, so an unconstrained
+		// pattern (a bare variable or a constant, arity 0) would otherwise
+		// reject every item with arguments before Unify runs. This mirrors the
+		// guard in the multi-pattern path.
+		if len(constraints.constPositions) > 0 || constraints.hasDisallowConstant || constraints.hasFormatConstraints {
+			if !constraints.matchesArgs(itemArgs) {
+				continue
+			}
+		}
+
+		delta, err := item.Unify(p)
+		if err != nil {
+			continue
+		}
+		result.Add(delta)
+	}
+
+	return result
+}
+
+func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name func(T) string, args func(T) []term.Term) *bindingSet {
 	log.Debugf("conflictSet( items=%d, body=%d )\n", len(items), len(body))
 
-	// Index items by name, keeping track of original indices
-	itemsByName := make(map[string][]int, len(items))
+	if len(body) == 1 {
+		return conflictSetSingle(items, body[0], indexable, name, args)
+	}
+
+	constraintsByBody := make([]argConstraints, len(body))
+	for i, p := range body {
+		constraintsByBody[i] = buildArgConstraints(args(p))
+	}
+	needsByKey, needAllIndices := collectIndexNeeds(body, indexable, name, constraintsByBody)
+
+	// Index items by name+arity and per-argument constants.
+	itemsByKey := make(map[conflictKey]*itemBucket, len(needsByKey))
 	for i, item := range items {
-		if indexable(item) {
-			itemsByName[name(item)] = append(itemsByName[name(item)], i)
+		if !indexable(item) {
+			continue
+		}
+		itemArgs := args(item)
+		key := conflictKey{name: name(item), arity: len(itemArgs)}
+		needs := needsByKey[key]
+		if needs == nil {
+			continue
+		}
+
+		bucket := itemsByKey[key]
+		if bucket == nil {
+			constIndexCap := 0
+			if needs.constPositions != nil {
+				constIndexCap = len(needs.constPositions)
+			}
+			bucket = &itemBucket{
+				constIndex: make(map[int]map[uint64][]int, constIndexCap),
+			}
+			itemsByKey[key] = bucket
+		}
+		bucket.indices = append(bucket.indices, i)
+		if len(needs.constPositions) == 0 {
+			continue
+		}
+		for pos, arg := range itemArgs {
+			if _, ok := needs.constPositions[pos]; !ok {
+				continue
+			}
+			if arg.GetType() != term.ConstantType {
+				continue
+			}
+			posMap := bucket.constIndex[pos]
+			if posMap == nil {
+				posMap = make(map[uint64][]int)
+				bucket.constIndex[pos] = posMap
+			}
+			hash := arg.Hash()
+			posMap[hash] = append(posMap[hash], i)
 		}
 	}
 
@@ -44,64 +351,70 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 	prefilter := make([][]int, n)
 	order := make([]int, n)
 
+	var allIndices []int
+	if needAllIndices {
+		allIndices = make([]int, len(items))
+		for j := range items {
+			allIndices[j] = j
+		}
+	}
+
 	for i, p := range body {
+		constraints := constraintsByBody[i]
+
 		var candIndices []int
 		if indexable(p) {
-			candIndices = itemsByName[name(p)]
-			if len(candIndices) == 0 {
+			key := conflictKey{name: name(p), arity: constraints.arity}
+			bucket := itemsByKey[key]
+			if bucket == nil || len(bucket.indices) == 0 {
 				// No matches possible at all.
-				return data.NewHashSet[*term.Binding]()
+				return newBindingSet()
 			}
-			// Filter by constants in p (cheap check before unification).
-			filtered := make([]int, 0, len(candIndices))
-			for _, idx := range candIndices {
-				f := items[idx]
-				ok := true
-				pArgs := args(p)
-				fArgs := args(f)
-				// This check assumes len(pArgs) == len(fArgs), which should hold for unification candidates.
-				if len(pArgs) == len(fArgs) {
-					for j, a := range pArgs {
-						if a.GetType() == term.ConstantType {
-							if !a.Equal(fArgs[j]) {
-								ok = false
-								break
-							}
-						}
-					}
-				} else {
-					ok = false
-				}
-
-				if ok {
-					filtered = append(filtered, idx)
+			candIndices = bucket.indices
+			if len(constraints.constPositions) > 0 {
+				candIndices = selectConstCandidates(bucket.constIndex, constraints.constPositions)
+				if len(candIndices) == 0 {
+					return newBindingSet()
 				}
 			}
-			prefilter[i] = filtered
 		} else {
 			// Fallback: no indexing possible, scan all items.
-			allIndices := make([]int, len(items))
-			for j := range items {
-				allIndices[j] = j
-			}
-			prefilter[i] = allIndices
+			candIndices = allIndices
 		}
+
+		if len(constraints.constPositions) == 0 && !constraints.hasDisallowConstant && !constraints.hasFormatConstraints {
+			prefilter[i] = candIndices
+			order[i] = i
+			continue
+		}
+
+		filtered := make([]int, 0, len(candIndices))
+		for _, idx := range candIndices {
+			fArgs := args(items[idx])
+			if constraints.matchesArgs(fArgs) {
+				filtered = append(filtered, idx)
+			}
+		}
+
+		prefilter[i] = filtered
 		order[i] = i
 	}
 	// Sort atoms by increasing number of prefiltered candidates to prune early.
 	sort.Slice(order, func(i, j int) bool { return len(prefilter[order[i]]) < len(prefilter[order[j]]) })
 
-	result := data.NewHashSet[*term.Binding]()
+	result := newBindingSet()
 
 	// Track which items from the original items slice have been used.
 	// This ensures multiset semantics s.t. each fact can only be consumed once.
-	// Use backtracking (mark/unmark) instead of copying map on each recursive call.
-	usedItems := make(map[int]bool)
+	// Use a binding trail (mark/unwind) so the DFS reuses one mutable binding
+	// instead of cloning at every branch.
+	usedItems := make([]bool, len(items))
+	trail := term.NewBindingTrail()
 
 	var dfs func(pos int, b *term.Binding)
 	dfs = func(pos int, b *term.Binding) {
 		if pos == n {
-			result.Add(b)
+			result.Add(b.Clone())
 			return
 		}
 
@@ -109,6 +422,7 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 		p := body[idx]
 		// Apply current binding once per depth.
 		ps := p.Subst(b)
+		psArgs := args(ps)
 
 		for _, itemIdx := range prefilter[idx] {
 			// Skip if this fact has already been used in this binding path
@@ -117,13 +431,31 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 			}
 
 			f := items[itemIdx]
-			if delta, err := f.Unify(ps); err == nil {
-				// Mark item as used (backtracking pattern)
-				usedItems[itemIdx] = true
-				dfs(pos+1, delta.Extend(b))
-				// Unmark item for other branches
-				delete(usedItems, itemIdx)
+			fArgs := args(f)
+			if len(psArgs) == len(fArgs) {
+				skip := false
+				for i, psArg := range psArgs {
+					if psArg.GetType() == term.ConstantType && fArgs[i].GetType() == term.ConstantType {
+						if !psArg.Equal(fArgs[i]) {
+							skip = true
+							break
+						}
+					}
+				}
+				if skip {
+					continue
+				}
 			}
+			delta, err := f.Unify(ps)
+			if err != nil {
+				continue
+			}
+			usedItems[itemIdx] = true
+			mark := trail.Mark()
+			b.MergeWithTrail(delta, trail)
+			dfs(pos+1, b)
+			b.Unwind(trail, mark)
+			usedItems[itemIdx] = false
 		}
 	}
 
@@ -133,7 +465,7 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 
 // conflictSetFacts matches a sequence of fact patterns against a multiset of facts.
 // It builds a per-predicate local index and uses DFS with early filtering by constants.
-func conflictSetFacts(facts []*rule.Fact, body []*rule.Fact) *data.HashSet[*term.Binding] {
+func conflictSetFacts(facts []*rule.Fact, body []*rule.Fact) *bindingSet {
 	return conflictSet(facts, body,
 		func(_ *rule.Fact) bool { return true },
 		func(f *rule.Fact) string { return f.Name },
@@ -143,7 +475,7 @@ func conflictSetFacts(facts []*rule.Fact, body []*rule.Fact) *data.HashSet[*term
 
 // conflictSetTerms matches a sequence of term patterns against a set of seen terms.
 // It builds a local index by function name and orders patterns by selectivity.
-func conflictSetTerms(seen []term.Term, body []term.Term) *data.HashSet[*term.Binding] {
+func conflictSetTerms(seen []term.Term, body []term.Term) *bindingSet {
 	return conflictSet(seen, body,
 		func(t term.Term) bool {
 			if fn, err := term.AsFunction(t); err == nil && fn != nil && fn.Name != term.PairFunctionName {
@@ -164,4 +496,48 @@ func conflictSetTerms(seen []term.Term, body []term.Term) *data.HashSet[*term.Bi
 			return nil
 		},
 	)
+}
+
+type bindingSet struct {
+	bindings []*term.Binding
+	seen     map[uint64][]int
+}
+
+func newBindingSet() *bindingSet {
+	return &bindingSet{
+		seen: make(map[uint64][]int),
+	}
+}
+
+func (s *bindingSet) Add(b *term.Binding) bool {
+	if b == nil {
+		return false
+	}
+	h := b.HashUnordered()
+	for _, idx := range s.seen[h] {
+		if s.bindings[idx].Equal(b) {
+			return false
+		}
+	}
+	s.seen[h] = append(s.seen[h], len(s.bindings))
+	s.bindings = append(s.bindings, b)
+	return true
+}
+
+func (s *bindingSet) Values() []*term.Binding {
+	if s == nil {
+		return nil
+	}
+	return s.bindings
+}
+
+func (s *bindingSet) Empty() bool {
+	return s == nil || len(s.bindings) == 0
+}
+
+func (s *bindingSet) Size() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.bindings)
 }

--- a/monitor/conflict_set_test.go
+++ b/monitor/conflict_set_test.go
@@ -1,0 +1,183 @@
+// This file is part of SpecMon.
+//
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package monitor
+
+import (
+	"testing"
+
+	"github.com/specmon/specmon/rule"
+	"github.com/specmon/specmon/term"
+)
+
+// bindTargets returns, for every binding in the set, the term that variable v
+// is bound to (skipping bindings that do not bind v). Used to assert which
+// seen terms a single-variable pattern matched.
+func bindTargets(bindings []*term.Binding, v *term.Variable) []term.Term {
+	var out []term.Term
+	for _, b := range bindings {
+		if t, ok := b.Get(v); ok {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// TestConflictSetTermsSingleBareVariable pins the single-pattern fast path for
+// a non-indexable body: a bare variable must match every seen term, regardless
+// of the seen term's arity. This is the common case (a rule with exactly one
+// trigger that substitutes to a variable) and a prior fast-path arity gate
+// silently dropped every seen term carrying arguments.
+func TestConflictSetTermsSingleBareVariable(t *testing.T) {
+	x := term.NewVariable("x")
+	body := []term.Term{x}
+
+	seen := []term.Term{
+		term.NewFunction("recv", []term.Term{term.NewConstant(1), term.NewConstant(2)}),
+		term.NewConstant("c"),
+		term.NewFunction("send", []term.Term{term.NewConstant(7)}),
+	}
+
+	got := conflictSetTerms(seen, body)
+	if got.Size() != len(seen) {
+		t.Fatalf("bare variable pattern: got %d bindings, want %d (one per seen term)", got.Size(), len(seen))
+	}
+	if len(bindTargets(got.Values(), x)) != len(seen) {
+		t.Fatalf("bare variable pattern: not every binding binds x")
+	}
+}
+
+// TestConflictSetTermsSingleConstant pins the single-pattern fast path for a
+// constant body pattern against an unevaluated ground term that Unify reduces
+// to that constant. The fast path must not pre-filter it out on arity before
+// Unify runs the reduction.
+func TestConflictSetTermsSingleConstant(t *testing.T) {
+	// cat(int(5)) is a ground, unevaluated function that Unify evaluates.
+	catTerm := term.NewFunction("cat", []term.Term{
+		term.NewFunction("int", []term.Term{term.NewConstant(5)}),
+	})
+	// The constant that cat(int(5)) evaluates to.
+	evaluated, err := term.Evaluate(catTerm)
+	if err != nil || evaluated == nil || evaluated.GetType() != term.ConstantType {
+		t.Skipf("cat(int(5)) did not evaluate to a constant in this build (err=%v); pattern precondition not met", err)
+	}
+
+	body := []term.Term{evaluated}
+	seen := []term.Term{catTerm}
+
+	got := conflictSetTerms(seen, body)
+	if got.Empty() {
+		t.Fatalf("constant pattern vs unevaluated ground cat: got 0 bindings, want 1")
+	}
+}
+
+// TestConflictSetTermsSingleIndexedFunction keeps the indexed single-pattern
+// path honest: a function pattern with a variable arg still matches same-name
+// same-arity seen terms and binds correctly.
+func TestConflictSetTermsSingleIndexedFunction(t *testing.T) {
+	y := term.NewVariable("y")
+	body := []term.Term{term.NewFunction("recv", []term.Term{y})}
+
+	seen := []term.Term{
+		term.NewFunction("recv", []term.Term{term.NewConstant(1)}),
+		term.NewFunction("send", []term.Term{term.NewConstant(2)}),                      // wrong name
+		term.NewFunction("recv", []term.Term{term.NewConstant(3), term.NewConstant(4)}), // wrong arity
+	}
+
+	got := conflictSetTerms(seen, body)
+	if got.Size() != 1 {
+		t.Fatalf("indexed single function pattern: got %d bindings, want 1 (only the matching recv/1)", got.Size())
+	}
+}
+
+// TestConflictSetFactsSingleVariableFact guards the fact path for a
+// single-pattern body with a variable argument: it must match same-name facts
+// of the same arity and bind the variable.
+func TestConflictSetFactsSingleVariableFact(t *testing.T) {
+	x := term.NewVariable("x")
+	body := []*rule.Fact{rule.NewFact("Out", []term.Term{x}, rule.LinearFact)}
+
+	facts := []*rule.Fact{
+		rule.NewFact("Out", []term.Term{term.NewConstant("a")}, rule.LinearFact),
+		rule.NewFact("Out", []term.Term{term.NewConstant("b")}, rule.LinearFact),
+		rule.NewFact("In", []term.Term{term.NewConstant("c")}, rule.LinearFact), // wrong name
+	}
+
+	got := conflictSetFacts(facts, body)
+	if got.Size() != 2 {
+		t.Fatalf("single variable fact pattern: got %d bindings, want 2", got.Size())
+	}
+}
+
+// TestConflictSetFactsDuplicateCap checks the body-slot dedup cap: two body
+// slots requesting Out(x), Out(y) against three identical Out facts should
+// still enumerate the pairings the uncapped code would, and capping past the
+// slot count must not drop a reachable binding.
+func TestConflictSetFactsDuplicateCap(t *testing.T) {
+	body := []*rule.Fact{
+		rule.NewFact("Out", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		rule.NewFact("Out", []term.Term{term.NewVariable("y")}, rule.LinearFact),
+	}
+	// Three identical facts; body needs at most 2 of them.
+	facts := []*rule.Fact{
+		rule.NewFact("Out", []term.Term{term.NewConstant("v")}, rule.LinearFact),
+		rule.NewFact("Out", []term.Term{term.NewConstant("v")}, rule.LinearFact),
+		rule.NewFact("Out", []term.Term{term.NewConstant("v")}, rule.LinearFact),
+	}
+
+	got := conflictSetFacts(facts, body)
+	// x and y each bind to the single distinct value "v"; the multiset yields
+	// exactly one distinct binding {x->v, y->v}.
+	if got.Empty() {
+		t.Fatalf("duplicate cap: got 0 bindings, want at least 1")
+	}
+}
+
+// TestBindingTrailOverwriteRestore pins the trail invariant the DFS relies on:
+// Mark, mutate (including overwriting an existing key), then Unwind must
+// restore the binding exactly, byte for byte.
+func TestBindingTrailOverwriteRestore(t *testing.T) {
+	x := term.NewVariable("x")
+	y := term.NewVariable("y")
+
+	b := term.NewBinding()
+	b.Set(x, term.NewConstant("orig"))
+	before := b.String()
+
+	trail := term.NewBindingTrail()
+	mark := trail.Mark()
+	// Overwrite an existing key and add a new one.
+	b.SetWithTrail(x, term.NewConstant("changed"), trail)
+	b.SetWithTrail(y, term.NewConstant("new"), trail)
+
+	if got, _ := b.Get(x); got == nil || got.String() != term.NewConstant("changed").String() {
+		t.Fatalf("after SetWithTrail, x not overwritten")
+	}
+	if _, ok := b.Get(y); !ok {
+		t.Fatalf("after SetWithTrail, y not added")
+	}
+
+	b.Unwind(trail, mark)
+	after := b.String()
+	if before != after {
+		t.Fatalf("Unwind did not restore binding: before=%q after=%q", before, after)
+	}
+	if _, ok := b.Get(y); ok {
+		t.Fatalf("Unwind did not remove y")
+	}
+}

--- a/term/binding.go
+++ b/term/binding.go
@@ -25,10 +25,30 @@ import (
 	"strings"
 
 	"github.com/specmon/specmon/data"
+	"github.com/specmon/specmon/utils"
 )
 
 type Binding struct {
 	m *data.HashMap[Term, Term]
+}
+
+// BindingTrail records inverse Set/Remove operations so a sequence of
+// in-place updates to a Binding can be undone in one call. It enables
+// backtracking DFS over a single mutable binding instead of cloning
+// the binding at every branch.
+type BindingTrail struct {
+	entries []bindingTrailEntry
+}
+
+type bindingTrailEntry struct {
+	key     Term
+	old     Term
+	existed bool
+}
+
+// NewBindingTrail returns an empty trail.
+func NewBindingTrail() *BindingTrail {
+	return &BindingTrail{}
 }
 
 func NewBinding() *Binding {
@@ -179,4 +199,90 @@ func (b *Binding) Clone() *Binding {
 
 func (b *Binding) Extend(bp *Binding) *Binding {
 	return &Binding{b.m.Extend(bp.m)}
+}
+
+// HashUnordered returns an order-independent hash of (k, v) pairs using XOR.
+// Use for deduplication where collisions are handled by Equal().
+// Cheaper than Hash() because it does not iterate sorted.
+func (b *Binding) HashUnordered() uint64 {
+	if b == nil || b.Empty() {
+		return 0
+	}
+	var h uint64
+	b.Iterate(func(k, v Term) bool {
+		// Mix key and value hashes, then XOR into the accumulator.
+		pair := utils.FNV64aUint64(k.Hash(), v.Hash())
+		h ^= pair
+		return true
+	})
+	return h
+}
+
+// Mark returns the current trail length so callers can Unwind back to this point.
+func (t *BindingTrail) Mark() int {
+	if t == nil {
+		return 0
+	}
+	return len(t.entries)
+}
+
+// SetWithTrail records the previous value (if any) at k before setting it to v.
+// When v equals the existing value the binding is left untouched and no trail
+// entry is appended.
+func (b *Binding) SetWithTrail(k, v Term, trail *BindingTrail) {
+	if trail == nil {
+		b.Set(k, v)
+		return
+	}
+	if old, ok := b.Get(k); ok {
+		if !old.Equal(v) {
+			trail.entries = append(trail.entries, bindingTrailEntry{
+				key:     k,
+				old:     old,
+				existed: true,
+			})
+			b.Set(k, v)
+		}
+		return
+	}
+	trail.entries = append(trail.entries, bindingTrailEntry{
+		key:     k,
+		existed: false,
+	})
+	b.Set(k, v)
+}
+
+// MergeWithTrail sets keys from other that are not already present in b, each
+// recorded on the trail so Unwind can restore the pre-merge state.
+func (b *Binding) MergeWithTrail(other *Binding, trail *BindingTrail) {
+	if other == nil || other.Empty() {
+		return
+	}
+	other.Iterate(func(k, v Term) bool {
+		if _, ok := b.Get(k); ok {
+			return true
+		}
+		b.SetWithTrail(k, v, trail)
+		return true
+	})
+}
+
+// Unwind rolls back trail entries after mark, restoring the binding to its
+// state at the matching Mark() call.
+func (b *Binding) Unwind(trail *BindingTrail, mark int) {
+	if trail == nil {
+		return
+	}
+	if mark < 0 || mark > len(trail.entries) {
+		mark = 0
+	}
+	for i := len(trail.entries) - 1; i >= mark; i-- {
+		entry := trail.entries[i]
+		if entry.existed {
+			b.Set(entry.key, entry.old)
+			continue
+		}
+		b.Remove(entry.key)
+	}
+	trail.entries = trail.entries[:mark]
 }

--- a/term/term.go
+++ b/term/term.go
@@ -129,9 +129,29 @@ type Function struct {
 	Args []Term `json:"args"`
 }
 
+// evaluatableFunctions contains function names that Evaluate() can reduce to constants.
+var evaluatableFunctions = map[string]bool{
+	CatFunctionName:   true,
+	AddFunctionName:   true,
+	AndFunctionName:   true,
+	OrFunctionName:    true,
+	SliceFunctionName: true,
+	ReverseFuncName:   true,
+}
+
 func (c *Constant[T]) GetType() string { return c.Type }
 func (v *Variable) GetType() string    { return v.Type }
 func (f *Function) GetType() string    { return f.Type }
+
+// MayEvalToConstant returns true if this function could potentially
+// evaluate to a constant value via Evaluate().
+// Returns false for unknown functions since Evaluate() doesn't reduce them.
+func (f *Function) MayEvalToConstant() bool {
+	if f == nil {
+		return false
+	}
+	return evaluatableFunctions[f.Name]
+}
 
 func NewConstant[T ConstantConstraint](value T) *Constant[T] {
 	return &Constant[T]{

--- a/utils/fnv.go
+++ b/utils/fnv.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package utils
+
+const fnv64Prime = 1099511628211
+
+// FNV64aUint64 hashes a uint64 into the provided FNV-1a state (little-endian).
+func FNV64aUint64(h uint64, v uint64) uint64 {
+	for i := 0; i < 8; i++ {
+		h ^= uint64(byte(v))
+		h *= fnv64Prime
+		v >>= 8
+	}
+
+	return h
+}


### PR DESCRIPTION
Speeds up conflictSet, the monitor's inner matching loop, without changing its results. Builds on the conflictSet extraction from #72.

conflictSet now indexes candidate items by (name, arity) with a secondary index over constant argument positions, so body atoms consume O(matching-items) per atom instead of scanning all items. The DFS backtracks a single mutable binding through a binding trail rather than cloning at every branch, and deduplicates results via an order-independent HashUnordered; existing callers are unchanged.

A second pass caps duplicate expansion at the body slot count: the DFS can never consume more matching items for a given (name, arity) key than there are body slots requesting it, so copies past that count are dropped. Multiset semantics are preserved via the existing usedItems tracking.

The single-pattern path applies the argument prefilter only when the pattern carries a real constraint. matchesArgs gates on arity first, so an unconstrained pattern (a bare variable or constant) would otherwise reject every item carrying arguments before Unify runs, dropping matches for the common single-trigger case. This mirrors the multi-pattern path.

Net effect on the wireguard workload (91k events): 2.6x faster than develop, event counts and peak memory unchanged.

Tests:

- conflict_set_test.go covers the single-pattern fast path for a bare variable and a constant against an unevaluated ground cat(...), the two cases the arity gate previously drnction path, the single-variable fact path, and the duplicate cap.
- TestBindingTrailOverwriteRestore pins the trail invariant the DFS depends on: Mark, overwrite plus add, then Unwind restores exactly.
