### PR TITLE
perf(monitor): Rework conflict-set matching and fact storage

### DIFF
--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -41,6 +41,11 @@ type Config struct {
 	// DeleteFact / Clone.
 	factCounts map[string]int
 
+	// factsByName buckets facts by predicate name so conflictSetFacts can
+	// iterate only the relevant predicate, not all of c.facts. Maintained
+	// incrementally by AddFact / DeleteFact / Clone.
+	factsByName map[string][]*rule.Fact
+
 	// seen is a multiset of events that have been seen in the current configuration
 	// and that have not been processed yet.
 	seen []term.Term
@@ -58,10 +63,11 @@ type Config struct {
 // NewConfig returns a new configuration.
 func NewConfig() *Config {
 	return &Config{
-		facts:      []*rule.Fact{},
-		factCounts: make(map[string]int),
-		seen:       []term.Term{},
-		trace:      []*rule.Fact{},
+		facts:       []*rule.Fact{},
+		factCounts:  make(map[string]int),
+		factsByName: make(map[string][]*rule.Fact),
+		seen:        []term.Term{},
+		trace:       []*rule.Fact{},
 	}
 }
 
@@ -86,6 +92,18 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 	} else {
 		c.factCounts[removed.Name] = n - 1
 	}
+	if bucket := c.factsByName[removed.Name]; len(bucket) > 0 {
+		// Remove the first matching pointer-or-equal entry from the bucket.
+		bi := slices.IndexFunc(bucket, func(s *rule.Fact) bool { return removed.Equal(s) })
+		if bi >= 0 {
+			bucket = slices.Delete(bucket, bi, bi+1)
+			if len(bucket) == 0 {
+				delete(c.factsByName, removed.Name)
+			} else {
+				c.factsByName[removed.Name] = bucket
+			}
+		}
+	}
 	c.invalidateHash()
 
 	log.Tracef("removed %s\n", t)
@@ -96,7 +114,14 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 func (c *Config) AddFact(t *rule.Fact) {
 	c.facts = append(c.facts, t)
 	c.factCounts[t.Name]++
+	c.factsByName[t.Name] = append(c.factsByName[t.Name], t)
 	c.invalidateHash()
+}
+
+// FactsByName returns the slice of facts in c whose predicate name matches.
+// The returned slice is owned by the Config; callers must not mutate it.
+func (c *Config) FactsByName(name string) []*rule.Fact {
+	return c.factsByName[name]
 }
 
 func (c *Config) Clone() *Config {
@@ -111,6 +136,17 @@ func (c *Config) Clone() *Config {
 		d.factCounts = make(map[string]int, len(c.factCounts))
 		for k, v := range c.factCounts {
 			d.factCounts[k] = v
+		}
+	}
+
+	// Copy the factsByName index so the clone can be mutated independently.
+	// The bucket slices are cloned (shallow), so each clone owns its slice
+	// header but the *rule.Fact pointers inside are shared (Facts are
+	// treated as immutable after construction).
+	if len(c.factsByName) > 0 {
+		d.factsByName = make(map[string][]*rule.Fact, len(c.factsByName))
+		for k, v := range c.factsByName {
+			d.factsByName[k] = slices.Clone(v)
 		}
 	}
 

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -31,7 +31,6 @@ import (
 	"github.com/specmon/specmon/term"
 )
 
-const queueSize = 1
 
 // Config is a configuration of the monitor.
 type Config struct {
@@ -44,8 +43,6 @@ type Config struct {
 
 	// trace is a list of action facts that have been recorded in the current configuration.
 	trace []*rule.Fact
-
-	queue chan []*rule.Fact
 }
 
 // NewConfig returns a new configuration.
@@ -54,7 +51,6 @@ func NewConfig() *Config {
 		facts: []*rule.Fact{},
 		seen:  []term.Term{},
 		trace: []*rule.Fact{},
-		queue: make(chan []*rule.Fact, queueSize),
 	}
 }
 
@@ -88,7 +84,6 @@ func (c *Config) Clone() *Config {
 	d.facts = slices.Clone(c.facts)
 	d.seen = slices.Clone(c.seen)
 	d.trace = slices.Clone(c.trace)
-	// c.queue cannot be cloned
 
 	return d
 }
@@ -191,7 +186,7 @@ func (c *Config) DeleteSeen(t term.Term) bool {
 
 // ApplyRule applies a rule to a configuration and returns the resulting configuration.
 // If ev is a tuple of the form <fn, ret>, then fn is replaced by ret.
-func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, error) {
+func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, []*rule.Fact, error) {
 	log.Infof("   applying rule %s\n", r.Name)
 
 	s := r.Subst(b)
@@ -203,7 +198,7 @@ func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, error) {
 	t = t.ReplaceFormats()
 
 	if !t.IsGround() {
-		return nil, fmt.Errorf("expected ground rule (%s), got variables: %v", t.Name, s.Vars())
+		return nil, nil, fmt.Errorf("expected ground rule (%s), got variables: %v", t.Name, s.Vars())
 	}
 
 	d := c.Clone()
@@ -211,7 +206,7 @@ func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, error) {
 	// Delete the facts from the LHS.
 	for _, f := range t.LHS {
 		if f.IsLinear() && !d.DeleteFact(f) {
-			return nil, fmt.Errorf("cannot delete non-existing fact '%s'", f)
+			return nil, nil, fmt.Errorf("cannot delete non-existing fact '%s'", f)
 		}
 	}
 
@@ -226,7 +221,7 @@ func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, error) {
 	// Triggers in s still contain formats.
 	for _, f := range s.Triggers() {
 		if !d.DeleteSeen(term.ReplaceFormats(f)) {
-			return nil, fmt.Errorf("cannot delete non-existing event '%s'", f)
+			return nil, nil, fmt.Errorf("cannot delete non-existing event '%s'", f)
 		}
 	}
 
@@ -234,18 +229,16 @@ func (c *Config) ApplyRule(r *rule.Rule, b *term.Binding) (*Config, error) {
 	// FIXME: For performance reasons, this is commented out.
 	// d.trace = append(d.trace, t.Act...)
 
-	d.queue <- t.Act
-
 	// Check if special event restrictions are satisfied.
 	if err := restrSatisfied(t.Act); err != nil {
 		// Don't wrap restriction violations to avoid redundant error messages
 		if errors.Is(err, ErrRestrictionViolated) {
-			return nil, err
+			return nil, nil, err
 		}
-		return nil, fmt.Errorf("rule not applied: %w", err)
+		return nil, nil, fmt.Errorf("rule not applied: %w", err)
 	}
 
-	return d, nil
+	return d, t.Act, nil
 }
 
 func splitTupleBinding(a term.Term) *term.Binding {

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -150,22 +150,6 @@ func (c *Config) AddFact(t *rule.Fact) {
 	c.invalidateHash()
 }
 
-// FactsByName returns a fresh slice of the facts whose predicate name
-// matches. The slice is independent of the Config's internal bucket so
-// callers may inspect or sort it without breaking factCount, the hash
-// cache, or copy-on-write ownership invariants. Returns nil when no
-// fact with that name exists.
-//
-// Internal call sites that need the bucket WITHOUT the per-call alloc
-// (the conflictSet hot path) read c.factsByName[name] directly.
-func (c *Config) FactsByName(name string) []*rule.Fact {
-	bucket := c.factsByName[name]
-	if len(bucket) == 0 {
-		return nil
-	}
-	return slices.Clone(bucket)
-}
-
 func (c *Config) Clone() *Config {
 	d := NewConfig()
 	d.seen = slices.Clone(c.seen)
@@ -200,12 +184,14 @@ func (c *Config) Clone() *Config {
 	return d
 }
 
-// FactsAsSlice is an alias for Facts kept for callers that already used
-// the older name.
-func (c *Config) FactsAsSlice() []*rule.Fact {
-	return c.Facts()
-}
-
+// FactsAsSliceWithName returns a fresh slice of the facts whose
+// predicate name matches. The slice is independent of the Config's
+// internal bucket so callers may inspect or sort it without breaking
+// factCount, the hash cache, or copy-on-write ownership invariants.
+// Returns nil when no fact with that name exists.
+//
+// Internal call sites that need the bucket WITHOUT the per-call alloc
+// (the conflictSet hot path) read c.factsByName[name] directly.
 func (c *Config) FactsAsSliceWithName(name string) []*rule.Fact {
 	bucket := c.factsByName[name]
 	if len(bucket) == 0 {

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"slices"
+	"sort"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -221,12 +222,37 @@ func (c *Config) CountByName(name string) int {
 	return len(c.factsByName[name])
 }
 
+// String returns a deterministic textual rendering of the config.
+//
+// factsByName is a Go map and its iteration order is randomised, so
+// the display order needs an explicit sort. Per-bucket facts are also
+// sorted so two configs with the same multiset of facts always
+// stringify identically. seen is a multiset of terms; same treatment.
+// trace is an ordered list (rule-application firing order) and is
+// rendered in insertion order.
+//
+// Determinism here is debug-output hygiene; the monitor no longer
+// uses String() for hash identity (RuleApplication.Hash and
+// Config.Hash both have explicit implementations).
 func (c *Config) String() string {
+	// Sort predicate-name keys for stable outer order.
+	names := make([]string, 0, len(c.factsByName))
+	for name := range c.factsByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
 	facts := make([]string, 0, c.factCount)
-	for _, bucket := range c.factsByName {
-		for _, f := range bucket {
-			facts = append(facts, f.String())
+	for _, name := range names {
+		bucket := c.factsByName[name]
+		bucketStrs := make([]string, len(bucket))
+		for i, f := range bucket {
+			bucketStrs[i] = f.String()
 		}
+		// Within a bucket the order is also map-derived (DFS through
+		// conflictSet's binding products), so sort for stability.
+		sort.Strings(bucketStrs)
+		facts = append(facts, bucketStrs...)
 	}
 	factsStr := strings.Join(facts, "\n")
 
@@ -234,6 +260,7 @@ func (c *Config) String() string {
 	for i := range c.seen {
 		seen[i] = c.seen[i].String()
 	}
+	sort.Strings(seen)
 	seenStr := strings.Join(seen, "\n")
 
 	trace := make([]string, len(c.trace))

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -217,9 +217,8 @@ func (c *Config) CountByName(name string) int {
 // trace is an ordered list (rule-application firing order) and is
 // rendered in insertion order.
 //
-// Determinism here is debug-output hygiene; the monitor no longer
-// uses String() for hash identity (RuleApplication.Hash and
-// Config.Hash both have explicit implementations).
+// Determinism here is debug-output hygiene; the monitor does not use
+// String() for identity (Config.Hash has an explicit implementation).
 func (c *Config) String() string {
 	// Sort predicate-name keys for stable outer order.
 	names := make([]string, 0, len(c.factsByName))

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -38,11 +38,26 @@ import (
 // all go through the bucketed view. The total fact count is tracked
 // incrementally in factCount so AddFact/DeleteFact don't have to sum
 // buckets, and Facts() materialises a flat view only on demand.
+//
+// Clone is SYMMETRIC copy-on-write: when c.Clone() returns d, BOTH
+// configs share the same bucket slice headers AND both have
+// ownedBuckets cleared. The first AddFact / DeleteFact on either side
+// allocates a fresh bucket via ensureOwned and records ownership on
+// that side only. The other side keeps the original shared array.
+// This keeps Clone O(distinct predicate names) and amortises bucket
+// copies to actual mutations, while ruling out the silent-corruption
+// hazard where the source mutates a bucket the clone still references.
 type Config struct {
 	// factsByName buckets facts by predicate name so conflictSetFacts can
 	// iterate only the relevant predicate. Maintained incrementally by
 	// AddFact / DeleteFact / Clone.
 	factsByName map[string][]*rule.Fact
+
+	// ownedBuckets[name] is true when this Config owns the slice header
+	// at factsByName[name] and is free to mutate it (append in place,
+	// slices.Delete). A bucket not in ownedBuckets is shared with the
+	// Clone source and must be copied before mutation.
+	ownedBuckets map[string]bool
 
 	// factCount is the total number of facts across all buckets, kept in
 	// sync with factsByName so callers don't have to sum bucket sizes.
@@ -65,10 +80,24 @@ type Config struct {
 // NewConfig returns a new configuration.
 func NewConfig() *Config {
 	return &Config{
-		factsByName: make(map[string][]*rule.Fact),
-		seen:        []term.Term{},
-		trace:       []*rule.Fact{},
+		factsByName:  make(map[string][]*rule.Fact),
+		ownedBuckets: make(map[string]bool),
+		seen:         []term.Term{},
+		trace:        []*rule.Fact{},
 	}
+}
+
+// ensureOwned returns a slice for predicate name that the caller is free
+// to mutate. If the current bucket is shared with a Clone source, it's
+// copied first.
+func (c *Config) ensureOwned(name string) []*rule.Fact {
+	if c.ownedBuckets[name] {
+		return c.factsByName[name]
+	}
+	bucket := slices.Clone(c.factsByName[name])
+	c.factsByName[name] = bucket
+	c.ownedBuckets[name] = true
+	return bucket
 }
 
 // Facts materialises the flat fact list by concatenating every bucket.
@@ -94,9 +123,14 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 		return false
 	}
 
+	// Take ownership before mutating in place. ensureOwned returns the
+	// (possibly copied) slice we should now update; the prior i is still
+	// valid because the indices match up to the deletion point.
+	bucket = c.ensureOwned(t.Name)
 	bucket = slices.Delete(bucket, i, i+1)
 	if len(bucket) == 0 {
 		delete(c.factsByName, t.Name)
+		delete(c.ownedBuckets, t.Name)
 	} else {
 		c.factsByName[t.Name] = bucket
 	}
@@ -109,7 +143,8 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 }
 
 func (c *Config) AddFact(t *rule.Fact) {
-	c.factsByName[t.Name] = append(c.factsByName[t.Name], t)
+	bucket := c.ensureOwned(t.Name)
+	c.factsByName[t.Name] = append(bucket, t)
 	c.factCount++
 	c.invalidateHash()
 }
@@ -136,15 +171,29 @@ func (c *Config) Clone() *Config {
 	d.trace = slices.Clone(c.trace)
 	d.factCount = c.factCount
 
-	// Copy the factsByName index so the clone can be mutated independently.
-	// The bucket slices are cloned (shallow), so each clone owns its slice
-	// header but the *rule.Fact pointers inside are shared (Facts are
-	// treated as immutable after construction).
+	// Copy the factsByName map header but share the bucket slice headers.
+	// d.ownedBuckets is empty (set in NewConfig) so d will copy-on-write
+	// on its first mutation per bucket.
 	if len(c.factsByName) > 0 {
 		d.factsByName = make(map[string][]*rule.Fact, len(c.factsByName))
 		for k, v := range c.factsByName {
-			d.factsByName[k] = slices.Clone(v)
+			d.factsByName[k] = v
 		}
+	}
+
+	// Symmetric step: relinquish ownership on the source. Any bucket
+	// that c previously owned is now shared with d, so the next
+	// mutation on c MUST also copy first via ensureOwned. Without this
+	// reset, a subsequent c.DeleteFact would short-circuit ensureOwned
+	// and slices.Delete would mutate the underlying array d still
+	// references, silently corrupting d's view.
+	//
+	// We allocate a fresh empty map rather than clear() the existing
+	// one because callers may have captured the old map header (none
+	// do today, but the semantics are simpler if Clone never aliases
+	// internal state across the two configs).
+	if len(c.ownedBuckets) > 0 {
+		c.ownedBuckets = make(map[string]bool)
 	}
 
 	return d

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -32,19 +32,21 @@ import (
 )
 
 // Config is a configuration of the monitor.
+//
+// Facts are stored bucketed by predicate name in factsByName; there is no
+// separate flat slice. CountByName / FactsByName / conflict-set callers
+// all go through the bucketed view. The total fact count is tracked
+// incrementally in factCount so AddFact/DeleteFact don't have to sum
+// buckets, and Facts() materialises a flat view only on demand.
 type Config struct {
-	// facts is a multiset of facts that are true in the current configuration.
-	facts []*rule.Fact
-
-	// factCounts indexes facts by predicate name so CountByName is O(1)
-	// instead of walking c.facts. Maintained incrementally by AddFact /
-	// DeleteFact / Clone.
-	factCounts map[string]int
-
 	// factsByName buckets facts by predicate name so conflictSetFacts can
-	// iterate only the relevant predicate, not all of c.facts. Maintained
-	// incrementally by AddFact / DeleteFact / Clone.
+	// iterate only the relevant predicate. Maintained incrementally by
+	// AddFact / DeleteFact / Clone.
 	factsByName map[string][]*rule.Fact
+
+	// factCount is the total number of facts across all buckets, kept in
+	// sync with factsByName so callers don't have to sum bucket sizes.
+	factCount int
 
 	// seen is a multiset of events that have been seen in the current configuration
 	// and that have not been processed yet.
@@ -63,47 +65,42 @@ type Config struct {
 // NewConfig returns a new configuration.
 func NewConfig() *Config {
 	return &Config{
-		facts:       []*rule.Fact{},
-		factCounts:  make(map[string]int),
 		factsByName: make(map[string][]*rule.Fact),
 		seen:        []term.Term{},
 		trace:       []*rule.Fact{},
 	}
 }
 
-// Facts returns the facts of the configuration.
+// Facts materialises the flat fact list by concatenating every bucket.
+// The returned slice is freshly allocated; the order is bucket-iteration
+// order (Go map iteration, not insertion order).
 func (c *Config) Facts() []*rule.Fact {
-	return c.facts
+	out := make([]*rule.Fact, 0, c.factCount)
+	for _, bucket := range c.factsByName {
+		out = append(out, bucket...)
+	}
+	return out
 }
 
 func (c *Config) DeleteFact(t *rule.Fact) bool {
-	i := slices.IndexFunc(c.facts, func(s *rule.Fact) bool {
+	bucket, ok := c.factsByName[t.Name]
+	if !ok {
+		return false
+	}
+	i := slices.IndexFunc(bucket, func(s *rule.Fact) bool {
 		return t.Equal(s)
 	})
-
 	if i == -1 {
 		return false
 	}
 
-	removed := c.facts[i]
-	c.facts = slices.Delete(c.facts, i, i+1)
-	if n := c.factCounts[removed.Name]; n <= 1 {
-		delete(c.factCounts, removed.Name)
+	bucket = slices.Delete(bucket, i, i+1)
+	if len(bucket) == 0 {
+		delete(c.factsByName, t.Name)
 	} else {
-		c.factCounts[removed.Name] = n - 1
+		c.factsByName[t.Name] = bucket
 	}
-	if bucket := c.factsByName[removed.Name]; len(bucket) > 0 {
-		// Remove the first matching pointer-or-equal entry from the bucket.
-		bi := slices.IndexFunc(bucket, func(s *rule.Fact) bool { return removed.Equal(s) })
-		if bi >= 0 {
-			bucket = slices.Delete(bucket, bi, bi+1)
-			if len(bucket) == 0 {
-				delete(c.factsByName, removed.Name)
-			} else {
-				c.factsByName[removed.Name] = bucket
-			}
-		}
-	}
+	c.factCount--
 	c.invalidateHash()
 
 	log.Tracef("removed %s\n", t)
@@ -112,32 +109,32 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 }
 
 func (c *Config) AddFact(t *rule.Fact) {
-	c.facts = append(c.facts, t)
-	c.factCounts[t.Name]++
 	c.factsByName[t.Name] = append(c.factsByName[t.Name], t)
+	c.factCount++
 	c.invalidateHash()
 }
 
-// FactsByName returns the slice of facts in c whose predicate name matches.
-// The returned slice is owned by the Config; callers must not mutate it.
+// FactsByName returns a fresh slice of the facts whose predicate name
+// matches. The slice is independent of the Config's internal bucket so
+// callers may inspect or sort it without breaking factCount, the hash
+// cache, or copy-on-write ownership invariants. Returns nil when no
+// fact with that name exists.
+//
+// Internal call sites that need the bucket WITHOUT the per-call alloc
+// (the conflictSet hot path) read c.factsByName[name] directly.
 func (c *Config) FactsByName(name string) []*rule.Fact {
-	return c.factsByName[name]
+	bucket := c.factsByName[name]
+	if len(bucket) == 0 {
+		return nil
+	}
+	return slices.Clone(bucket)
 }
 
 func (c *Config) Clone() *Config {
 	d := NewConfig()
-	d.facts = slices.Clone(c.facts)
 	d.seen = slices.Clone(c.seen)
 	d.trace = slices.Clone(c.trace)
-
-	// Copy the factCounts map so further mutations on the clone don't
-	// disturb the original.
-	if len(c.factCounts) > 0 {
-		d.factCounts = make(map[string]int, len(c.factCounts))
-		for k, v := range c.factCounts {
-			d.factCounts[k] = v
-		}
-	}
+	d.factCount = c.factCount
 
 	// Copy the factsByName index so the clone can be mutated independently.
 	// The bucket slices are cloned (shallow), so each clone owns its slice
@@ -153,33 +150,34 @@ func (c *Config) Clone() *Config {
 	return d
 }
 
+// FactsAsSlice is an alias for Facts kept for callers that already used
+// the older name.
 func (c *Config) FactsAsSlice() []*rule.Fact {
-	return c.facts
+	return c.Facts()
 }
 
 func (c *Config) FactsAsSliceWithName(name string) []*rule.Fact {
-	var T []*rule.Fact
-	for _, t := range c.facts {
-		if t.Name == name {
-			T = append(T, t)
-		}
+	bucket := c.factsByName[name]
+	if len(bucket) == 0 {
+		return nil
 	}
-
-	return T
+	return slices.Clone(bucket)
 }
 
 // CountByName returns how many facts in c carry the given predicate name.
 // Used by the rule-applicability gate to skip rules whose LHS requires
 // more instances of a predicate than the config currently has. O(1)
-// via the factCounts index maintained by AddFact / DeleteFact.
+// via factsByName.
 func (c *Config) CountByName(name string) int {
-	return c.factCounts[name]
+	return len(c.factsByName[name])
 }
 
 func (c *Config) String() string {
-	facts := make([]string, len(c.facts))
-	for i := range c.facts {
-		facts[i] = c.facts[i].String()
+	facts := make([]string, 0, c.factCount)
+	for _, bucket := range c.factsByName {
+		for _, f := range bucket {
+			facts = append(facts, f.String())
+		}
 	}
 	factsStr := strings.Join(facts, "\n")
 
@@ -198,37 +196,110 @@ func (c *Config) String() string {
 	return fmt.Sprintf("{ [ %s ] | %s | %s }", factsStr, seenStr, traceStr)
 }
 
+// Hash returns a canonical 64-bit digest of the configuration. The result
+// is independent of the order in which facts were added (multiset
+// semantics) but DEPENDS on multiplicity: [F, F] hashes differently from
+// [F] and from []. This is required for correctness because
+// data.HashMap.Set keys solely by the returned hash (no Equal fallback),
+// so any cardinality collision would silently merge structurally
+// distinct configurations.
+//
+// Implementation: each fact / seen-event contributes a 64-bit mixed
+// hash that is then ADDED (uint64, wrapping) into the section
+// accumulator. Sum is associative-commutative, so the digest is
+// order-independent. Unlike XOR, sum does not cancel duplicates:
+// 2 * h(F) != 0, so [F, F] and [] produce different accumulators.
+// Sum is O(N) with zero allocations, matching the original XOR
+// implementation's hot-path cost.
+//
+// Each fact hash is "mixed" through a multiplier before summing.
+// Without mixing, raw 64-bit FNV-1a values cluster in the low bits
+// for short keys and the sum becomes biased. The mixer is a single
+// xorshift+multiply step from splitmix64, which is cheap and
+// produces a good avalanche.
+//
+// The three sections are folded into one final FNV-1a value with a
+// section-tag byte and section length so a fact and a seen-event
+// with equal hashes contribute distinct bytes, and so sections of
+// different lengths cannot alias.
+//
+// The result is memoised in hashCache; mutators must call invalidateHash.
 func (c *Config) Hash() uint64 {
 	if c.hashCacheSet {
 		return c.hashCache
 	}
+
+	var factsAcc uint64
+	for _, bucket := range c.factsByName {
+		for _, f := range bucket {
+			factsAcc += mix64(f.Hash())
+		}
+	}
+
+	var seenAcc uint64
+	for _, t := range c.seen {
+		seenAcc += mix64(t.Hash())
+	}
+
+	// trace is ordered: rule applications are recorded in firing
+	// order. Multiply by a step constant so swapping two entries
+	// changes the digest. If trace ever becomes a multiset, replace
+	// this loop with the sum pattern above.
+	var traceAcc uint64
+	for i, f := range c.trace {
+		traceAcc += mix64(f.Hash()) * uint64(i+1)
+	}
+
 	h := fnv.New64a()
+	var buf [8]byte
+	// Sections are tagged + length-prefixed so cross-section
+	// aliasing on equal accumulator values is impossible.
+	h.Write([]byte{hashSectionFacts})
+	// factCount is a fact tally maintained by AddFact/DeleteFact and is
+	// never negative, so the uint64 conversion cannot overflow.
+	binary.LittleEndian.PutUint64(buf[:], uint64(c.factCount)) //nolint:gosec
+	h.Write(buf[:])
+	binary.LittleEndian.PutUint64(buf[:], factsAcc)
+	h.Write(buf[:])
 
-	for _, f := range c.facts {
-		hash := f.Hash()
-		var buf [8]byte
-		binary.LittleEndian.PutUint64(buf[:], hash)
-		h.Write(buf[:])
-	}
+	h.Write([]byte{hashSectionSeen})
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.seen)))
+	h.Write(buf[:])
+	binary.LittleEndian.PutUint64(buf[:], seenAcc)
+	h.Write(buf[:])
 
-	for _, f := range c.trace {
-		hash := f.Hash()
-		var buf [8]byte
-		binary.LittleEndian.PutUint64(buf[:], hash)
-		h.Write(buf[:])
-	}
-
-	for _, f := range c.seen {
-		hash := f.Hash()
-		var buf [8]byte
-		binary.LittleEndian.PutUint64(buf[:], hash)
-		h.Write(buf[:])
-	}
+	h.Write([]byte{hashSectionTrace})
+	binary.LittleEndian.PutUint64(buf[:], uint64(len(c.trace)))
+	h.Write(buf[:])
+	binary.LittleEndian.PutUint64(buf[:], traceAcc)
+	h.Write(buf[:])
 
 	c.hashCache = h.Sum64()
 	c.hashCacheSet = true
 	return c.hashCache
 }
+
+// mix64 is the splitmix64 finalizer (Stafford variant 13). It
+// scrambles low-bit clustering in FNV-1a output so the per-section
+// sum has good avalanche even when many input hashes share their
+// low bits.
+func mix64(x uint64) uint64 {
+	x ^= x >> 30
+	x *= 0xbf58476d1ce4e5b9
+	x ^= x >> 27
+	x *= 0x94d049bb133111eb
+	x ^= x >> 31
+	return x
+}
+
+// Section tags used in Hash(); changing these values invalidates the
+// memoised digests of any persisted configuration set, but those are
+// never written to disk so a renumbering is safe.
+const (
+	hashSectionFacts byte = 1
+	hashSectionSeen  byte = 2
+	hashSectionTrace byte = 3
+)
 
 // invalidateHash clears the memoized Hash. Callers that mutate facts,
 // seen, or trace must call this so the next Hash() recomputes.

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -36,6 +36,11 @@ type Config struct {
 	// facts is a multiset of facts that are true in the current configuration.
 	facts []*rule.Fact
 
+	// factCounts indexes facts by predicate name so CountByName is O(1)
+	// instead of walking c.facts. Maintained incrementally by AddFact /
+	// DeleteFact / Clone.
+	factCounts map[string]int
+
 	// seen is a multiset of events that have been seen in the current configuration
 	// and that have not been processed yet.
 	seen []term.Term
@@ -53,9 +58,10 @@ type Config struct {
 // NewConfig returns a new configuration.
 func NewConfig() *Config {
 	return &Config{
-		facts: []*rule.Fact{},
-		seen:  []term.Term{},
-		trace: []*rule.Fact{},
+		facts:      []*rule.Fact{},
+		factCounts: make(map[string]int),
+		seen:       []term.Term{},
+		trace:      []*rule.Fact{},
 	}
 }
 
@@ -73,7 +79,13 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 		return false
 	}
 
+	removed := c.facts[i]
 	c.facts = slices.Delete(c.facts, i, i+1)
+	if n := c.factCounts[removed.Name]; n <= 1 {
+		delete(c.factCounts, removed.Name)
+	} else {
+		c.factCounts[removed.Name] = n - 1
+	}
 	c.invalidateHash()
 
 	log.Tracef("removed %s\n", t)
@@ -83,6 +95,7 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 
 func (c *Config) AddFact(t *rule.Fact) {
 	c.facts = append(c.facts, t)
+	c.factCounts[t.Name]++
 	c.invalidateHash()
 }
 
@@ -91,6 +104,15 @@ func (c *Config) Clone() *Config {
 	d.facts = slices.Clone(c.facts)
 	d.seen = slices.Clone(c.seen)
 	d.trace = slices.Clone(c.trace)
+
+	// Copy the factCounts map so further mutations on the clone don't
+	// disturb the original.
+	if len(c.factCounts) > 0 {
+		d.factCounts = make(map[string]int, len(c.factCounts))
+		for k, v := range c.factCounts {
+			d.factCounts[k] = v
+		}
+	}
 
 	return d
 }
@@ -112,16 +134,10 @@ func (c *Config) FactsAsSliceWithName(name string) []*rule.Fact {
 
 // CountByName returns how many facts in c carry the given predicate name.
 // Used by the rule-applicability gate to skip rules whose LHS requires
-// more instances of a predicate than the config currently has. Linear in
-// the size of c.facts.
+// more instances of a predicate than the config currently has. O(1)
+// via the factCounts index maintained by AddFact / DeleteFact.
 func (c *Config) CountByName(name string) int {
-	n := 0
-	for _, t := range c.facts {
-		if t.Name == name {
-			n++
-		}
-	}
-	return n
+	return c.factCounts[name]
 }
 
 func (c *Config) String() string {

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -108,6 +108,20 @@ func (c *Config) FactsAsSliceWithName(name string) []*rule.Fact {
 	return T
 }
 
+// CountByName returns how many facts in c carry the given predicate name.
+// Used by the rule-applicability gate to skip rules whose LHS requires
+// more instances of a predicate than the config currently has. Linear in
+// the size of c.facts.
+func (c *Config) CountByName(name string) int {
+	n := 0
+	for _, t := range c.facts {
+		if t.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
 func (c *Config) String() string {
 	facts := make([]string, len(c.facts))
 	for i := range c.facts {

--- a/monitor/configuration.go
+++ b/monitor/configuration.go
@@ -31,7 +31,6 @@ import (
 	"github.com/specmon/specmon/term"
 )
 
-
 // Config is a configuration of the monitor.
 type Config struct {
 	// facts is a multiset of facts that are true in the current configuration.
@@ -43,6 +42,12 @@ type Config struct {
 
 	// trace is a list of action facts that have been recorded in the current configuration.
 	trace []*rule.Fact
+
+	// hashCache memoizes Hash() so repeated lookups in HashSet[*Config]
+	// don't re-walk all facts/seen/trace per call. Any mutation must
+	// call invalidateHash().
+	hashCache    uint64
+	hashCacheSet bool
 }
 
 // NewConfig returns a new configuration.
@@ -69,6 +74,7 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 	}
 
 	c.facts = slices.Delete(c.facts, i, i+1)
+	c.invalidateHash()
 
 	log.Tracef("removed %s\n", t)
 
@@ -77,6 +83,7 @@ func (c *Config) DeleteFact(t *rule.Fact) bool {
 
 func (c *Config) AddFact(t *rule.Fact) {
 	c.facts = append(c.facts, t)
+	c.invalidateHash()
 }
 
 func (c *Config) Clone() *Config {
@@ -140,6 +147,9 @@ func (c *Config) String() string {
 }
 
 func (c *Config) Hash() uint64 {
+	if c.hashCacheSet {
+		return c.hashCache
+	}
 	h := fnv.New64a()
 
 	for _, f := range c.facts {
@@ -163,11 +173,21 @@ func (c *Config) Hash() uint64 {
 		h.Write(buf[:])
 	}
 
-	return h.Sum64()
+	c.hashCache = h.Sum64()
+	c.hashCacheSet = true
+	return c.hashCache
+}
+
+// invalidateHash clears the memoized Hash. Callers that mutate facts,
+// seen, or trace must call this so the next Hash() recomputes.
+func (c *Config) invalidateHash() {
+	c.hashCache = 0
+	c.hashCacheSet = false
 }
 
 func (c *Config) AddSeen(t term.Term) {
 	c.seen = append(c.seen, t)
+	c.invalidateHash()
 }
 
 func (c *Config) DeleteSeen(t term.Term) bool {
@@ -180,6 +200,7 @@ func (c *Config) DeleteSeen(t term.Term) bool {
 	}
 
 	c.seen = slices.Delete(c.seen, i, i+1)
+	c.invalidateHash()
 
 	return true
 }

--- a/monitor/configuration_test.go
+++ b/monitor/configuration_test.go
@@ -1,0 +1,209 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package monitor_test
+
+import (
+	"testing"
+
+	"github.com/specmon/specmon/data"
+	"github.com/specmon/specmon/monitor"
+	"github.com/specmon/specmon/rule"
+	"github.com/specmon/specmon/term"
+)
+
+func newFFact(args ...term.Term) *rule.Fact {
+	return rule.NewFact("F", args, rule.LinearFact)
+}
+
+// TestConfigHashPreservesMultiplicity guards against the XOR-cancellation
+// bug where [F, F] and [] hashed to the same value because F.Hash() ^
+// F.Hash() = 0. Since data.HashMap keys solely by Config.Hash() with no
+// Equal fallback, a collision here silently merges structurally distinct
+// configurations.
+func TestConfigHashPreservesMultiplicity(t *testing.T) {
+	f := newFFact(term.NewConstant("a"))
+
+	empty := monitor.NewConfig()
+
+	singleton := monitor.NewConfig()
+	singleton.AddFact(f)
+
+	doubled := monitor.NewConfig()
+	doubled.AddFact(f)
+	doubled.AddFact(f)
+
+	tripled := monitor.NewConfig()
+	tripled.AddFact(f)
+	tripled.AddFact(f)
+	tripled.AddFact(f)
+
+	hashes := map[string]uint64{
+		"empty":     empty.Hash(),
+		"singleton": singleton.Hash(),
+		"doubled":   doubled.Hash(),
+		"tripled":   tripled.Hash(),
+	}
+
+	for nameA, hA := range hashes {
+		for nameB, hB := range hashes {
+			if nameA == nameB {
+				continue
+			}
+			if hA == hB {
+				t.Errorf("Hash() collision between %s and %s (both = %d) — multiplicity not preserved",
+					nameA, nameB, hA)
+			}
+		}
+	}
+}
+
+// TestConfigHashOrderIndependent verifies that the order in which facts
+// are added does NOT affect the hash. This is the intended multiset
+// behavior that the original (order-dependent) FNV streaming lacked.
+func TestConfigHashOrderIndependent(t *testing.T) {
+	fa := newFFact(term.NewConstant("a"))
+	fb := newFFact(term.NewConstant("b"))
+	fc := newFFact(term.NewConstant("c"))
+
+	ab := monitor.NewConfig()
+	ab.AddFact(fa)
+	ab.AddFact(fb)
+	ab.AddFact(fc)
+
+	ba := monitor.NewConfig()
+	ba.AddFact(fc)
+	ba.AddFact(fa)
+	ba.AddFact(fb)
+
+	if ab.Hash() != ba.Hash() {
+		t.Errorf("Hash() depends on insertion order: %d != %d", ab.Hash(), ba.Hash())
+	}
+}
+
+// TestConfigHashSetDistinguishesDuplicates is the integration test for
+// the multiplicity guarantee: two configs that differ only in fact
+// multiplicity must coexist in data.HashSet[*Config]. data.HashMap keys
+// by hash and has no Equal fallback, so this only passes if Hash()
+// itself separates them.
+func TestConfigHashSetDistinguishesDuplicates(t *testing.T) {
+	f := newFFact(term.NewConstant("a"))
+
+	singleton := monitor.NewConfig()
+	singleton.AddFact(f)
+
+	doubled := monitor.NewConfig()
+	doubled.AddFact(f)
+	doubled.AddFact(f)
+
+	set := data.NewHashSet[*monitor.Config]()
+	set.Add(singleton)
+	set.Add(doubled)
+
+	if set.Size() != 2 {
+		t.Errorf("HashSet collapsed two configs differing in multiplicity: size = %d, want 2", set.Size())
+	}
+}
+
+// TestConfigHashSeenSeparate verifies that a fact and a term hashed
+// equally do not cancel across the facts/seen sections.
+func TestConfigHashSeenSeparate(t *testing.T) {
+	a := term.NewConstant("a")
+	fa := newFFact(a)
+
+	withFact := monitor.NewConfig()
+	withFact.AddFact(fa)
+
+	withSeen := monitor.NewConfig()
+	withSeen.AddSeen(a)
+
+	if withFact.Hash() == withSeen.Hash() {
+		t.Errorf("Hash() does not separate facts from seen events: both hash to %d", withFact.Hash())
+	}
+}
+
+// TestConfigHashLengthSensitivity guards against the sum-collision case
+// where mix(F) + mix(G) happens to equal 2*mix(H). Even when section
+// accumulators tie, the length prefix folded into the final FNV-1a
+// must keep distinct-cardinality configs apart.
+func TestConfigHashLengthSensitivity(t *testing.T) {
+	f := newFFact(term.NewConstant("f"))
+	g := newFFact(term.NewConstant("g"))
+	h := newFFact(term.NewConstant("h"))
+
+	two := monitor.NewConfig()
+	two.AddFact(f)
+	two.AddFact(g)
+
+	one := monitor.NewConfig()
+	one.AddFact(h)
+
+	// Even if (extremely unlikely) the accumulators tied, factCount
+	// differs and is folded into the digest. The configs MUST hash
+	// differently.
+	if two.Hash() == one.Hash() {
+		t.Errorf("Hash() collapsed configs with different fact counts: both = %d", two.Hash())
+	}
+}
+
+// TestConfigHashCacheInvalidated verifies the cache is cleared on
+// mutation. A stale cache would let a config hash to its old value
+// after AddFact/DeleteFact/AddSeen/DeleteSeen.
+func TestConfigHashCacheInvalidated(t *testing.T) {
+	c := monitor.NewConfig()
+	before := c.Hash()
+	c.AddFact(newFFact(term.NewConstant("a")))
+	after := c.Hash()
+	if before == after {
+		t.Errorf("Hash() returned cached value after AddFact: %d", before)
+	}
+}
+
+// BenchmarkConfigHashCold measures uncached Config.Hash() cost for a
+// realistic config size. Cache is invalidated each iteration via AddFact
+// so we measure the full recomputation path.
+func BenchmarkConfigHashCold(b *testing.B) {
+	c := monitor.NewConfig()
+	for i := 0; i < 100; i++ {
+		c.AddFact(newFFact(term.NewConstant("v"), term.NewConstant(i)))
+	}
+	// Warm one fact so we can re-add it cheaply.
+	probe := newFFact(term.NewConstant("probe"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// AddFact invalidates the cache; the immediate Hash() then
+		// recomputes from scratch.
+		c.AddFact(probe)
+		_ = c.Hash()
+	}
+}
+
+// BenchmarkConfigHashHot measures the cached path. With the cache
+// working, repeated Hash() calls should be a single map lookup +
+// branch.
+func BenchmarkConfigHashHot(b *testing.B) {
+	c := monitor.NewConfig()
+	for i := 0; i < 100; i++ {
+		c.AddFact(newFFact(term.NewConstant("v"), term.NewConstant(i)))
+	}
+	_ = c.Hash() // warm cache
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = c.Hash()
+	}
+}

--- a/monitor/configuration_test.go
+++ b/monitor/configuration_test.go
@@ -207,3 +207,120 @@ func BenchmarkConfigHashHot(b *testing.B) {
 		_ = c.Hash()
 	}
 }
+
+// hasFact reports whether c.FactsByName(name) contains a fact Equal
+// to f. Used by Clone tests as a structural check that does not rely
+// on slice-header identity.
+func hasFact(c *monitor.Config, f *rule.Fact) bool {
+	for _, g := range c.FactsByName(f.Name) {
+		if g != nil && g.Equal(f) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCloneSourceMutationDoesNotCorruptClone guards the Fix 3
+// invariant: after c.Clone() returns d, ANY subsequent mutation on c
+// must not be observable in d. Before the fix Clone left
+// c.ownedBuckets unchanged, so c.DeleteFact would short-circuit
+// ensureOwned and mutate the bucket array shared with d, corrupting
+// d's view of the deleted fact.
+func TestCloneSourceMutationDoesNotCorruptClone(t *testing.T) {
+	f := newFFact(term.NewConstant("a"))
+
+	c := monitor.NewConfig()
+	c.AddFact(f)
+
+	d := c.Clone()
+	if !hasFact(d, f) {
+		t.Fatalf("d is missing f immediately after Clone")
+	}
+
+	// Mutate the source; the clone must not change.
+	if !c.DeleteFact(f) {
+		t.Fatalf("c.DeleteFact(f) returned false; precondition broken")
+	}
+
+	if !hasFact(d, f) {
+		t.Errorf("c.DeleteFact corrupted d: d no longer contains f. "+
+			"Bucket = %v", d.FactsByName(f.Name))
+	}
+	// Stronger: the slice header length must still match what d had
+	// before the mutation. slices.Delete shifts and shortens the
+	// source's slice; the clone's slice header is independent so its
+	// length must be unchanged.
+	if got := len(d.FactsByName(f.Name)); got != 1 {
+		t.Errorf("d.FactsByName(F) length changed after c mutation: got %d, want 1", got)
+	}
+}
+
+// TestCloneSourceAddDoesNotCorruptClone covers the AddFact path: if c
+// adds a fact AFTER cloning, the clone must not silently gain that
+// fact through a shared underlying array. AddFact uses append, which
+// CAN reuse the existing array's spare capacity; ensureOwned must
+// copy first.
+func TestCloneSourceAddDoesNotCorruptClone(t *testing.T) {
+	f := newFFact(term.NewConstant("a"))
+	g := newFFact(term.NewConstant("b"))
+
+	c := monitor.NewConfig()
+	c.AddFact(f)
+	// At this point c.factsByName["F"] is a length-1 slice. Cap may be
+	// 1 (no spare) or 2+ (depending on growth policy). To stress the
+	// spare-cap path, pre-grow the bucket. AddFact then DeleteFact
+	// gives the slice spare capacity.
+	c.AddFact(g)
+	c.DeleteFact(g) // bucket back to [f] with cap >= 2
+
+	d := c.Clone()
+	if len(d.FactsByName(f.Name)) != 1 {
+		t.Fatalf("d should have one fact; got %d", len(d.FactsByName(f.Name)))
+	}
+
+	// Add a fresh fact to c. If c kept ownership and append reuses
+	// the spare slot, the underlying array's [1] becomes the new
+	// fact, but d's slice header still says length 1 so d doesn't
+	// see it directly. The smoking gun: if we then mutate c's
+	// slice contents (e.g. via DeleteFact), d's [0] would shift.
+	h := newFFact(term.NewConstant("c"))
+	c.AddFact(h)
+
+	// Now delete f from c. With the bug, slices.Delete on the shared
+	// array shifts h into slot 0 of d's view.
+	if !c.DeleteFact(f) {
+		t.Fatalf("c.DeleteFact(f) returned false")
+	}
+
+	bucket := d.FactsByName(f.Name)
+	if len(bucket) != 1 {
+		t.Fatalf("d.FactsByName length changed: got %d, want 1", len(bucket))
+	}
+	if bucket[0] == nil || !bucket[0].Equal(f) {
+		t.Errorf("d's bucket[0] was mutated by c's later AddFact + DeleteFact: got %v, want F(a)", bucket[0])
+	}
+}
+
+// TestCloneIsolatedAcrossSiblings covers the case of two clones from
+// the same source: mutations on one sibling must not be observed by
+// the other. Same shared-array hazard, just between two clones.
+func TestCloneIsolatedAcrossSiblings(t *testing.T) {
+	f := newFFact(term.NewConstant("a"))
+
+	c := monitor.NewConfig()
+	c.AddFact(f)
+
+	d1 := c.Clone()
+	d2 := c.Clone()
+
+	if !d1.DeleteFact(f) {
+		t.Fatalf("d1.DeleteFact(f) returned false")
+	}
+
+	if !hasFact(d2, f) {
+		t.Errorf("d1's DeleteFact leaked into d2")
+	}
+	if !hasFact(c, f) {
+		t.Errorf("d1's DeleteFact leaked into c")
+	}
+}

--- a/monitor/configuration_test.go
+++ b/monitor/configuration_test.go
@@ -324,3 +324,37 @@ func TestCloneIsolatedAcrossSiblings(t *testing.T) {
 		t.Errorf("d1's DeleteFact leaked into c")
 	}
 }
+
+// TestConfigStringDeterministic verifies String() output is independent
+// of the order facts were added. factsByName is a Go map and
+// String() previously iterated it directly, giving randomised output
+// across runs - the bug that made RuleApplication's fmt.Sprintf-based
+// dedup non-deterministic before this branch added RuleApplication.Hash.
+func TestConfigStringDeterministic(t *testing.T) {
+	a := rule.NewFact("A", []term.Term{term.NewConstant("1")}, rule.LinearFact)
+	b := rule.NewFact("B", []term.Term{term.NewConstant("2")}, rule.LinearFact)
+	c := rule.NewFact("C", []term.Term{term.NewConstant("3")}, rule.LinearFact)
+
+	c1 := monitor.NewConfig()
+	c1.AddFact(a)
+	c1.AddFact(b)
+	c1.AddFact(c)
+
+	c2 := monitor.NewConfig()
+	c2.AddFact(c)
+	c2.AddFact(a)
+	c2.AddFact(b)
+
+	if c1.String() != c2.String() {
+		t.Errorf("String() order-dependent:\n  c1 = %q\n  c2 = %q", c1.String(), c2.String())
+	}
+
+	// Stronger: identical configs must stringify identically across
+	// multiple calls on the same receiver (Go map iteration is
+	// randomised per-iteration even for an unchanged map).
+	for i := 0; i < 10; i++ {
+		if c1.String() != c2.String() {
+			t.Errorf("String() non-deterministic across calls at i=%d", i)
+		}
+	}
+}

--- a/monitor/configuration_test.go
+++ b/monitor/configuration_test.go
@@ -208,11 +208,11 @@ func BenchmarkConfigHashHot(b *testing.B) {
 	}
 }
 
-// hasFact reports whether c.FactsByName(name) contains a fact Equal
+// hasFact reports whether c.FactsAsSliceWithName(name) contains a fact Equal
 // to f. Used by Clone tests as a structural check that does not rely
 // on slice-header identity.
 func hasFact(c *monitor.Config, f *rule.Fact) bool {
-	for _, g := range c.FactsByName(f.Name) {
+	for _, g := range c.FactsAsSliceWithName(f.Name) {
 		if g != nil && g.Equal(f) {
 			return true
 		}
@@ -244,14 +244,14 @@ func TestCloneSourceMutationDoesNotCorruptClone(t *testing.T) {
 
 	if !hasFact(d, f) {
 		t.Errorf("c.DeleteFact corrupted d: d no longer contains f. "+
-			"Bucket = %v", d.FactsByName(f.Name))
+			"Bucket = %v", d.FactsAsSliceWithName(f.Name))
 	}
 	// Stronger: the slice header length must still match what d had
 	// before the mutation. slices.Delete shifts and shortens the
 	// source's slice; the clone's slice header is independent so its
 	// length must be unchanged.
-	if got := len(d.FactsByName(f.Name)); got != 1 {
-		t.Errorf("d.FactsByName(F) length changed after c mutation: got %d, want 1", got)
+	if got := len(d.FactsAsSliceWithName(f.Name)); got != 1 {
+		t.Errorf("d.FactsAsSliceWithName(F) length changed after c mutation: got %d, want 1", got)
 	}
 }
 
@@ -274,8 +274,8 @@ func TestCloneSourceAddDoesNotCorruptClone(t *testing.T) {
 	c.DeleteFact(g) // bucket back to [f] with cap >= 2
 
 	d := c.Clone()
-	if len(d.FactsByName(f.Name)) != 1 {
-		t.Fatalf("d should have one fact; got %d", len(d.FactsByName(f.Name)))
+	if len(d.FactsAsSliceWithName(f.Name)) != 1 {
+		t.Fatalf("d should have one fact; got %d", len(d.FactsAsSliceWithName(f.Name)))
 	}
 
 	// Add a fresh fact to c. If c kept ownership and append reuses
@@ -292,9 +292,9 @@ func TestCloneSourceAddDoesNotCorruptClone(t *testing.T) {
 		t.Fatalf("c.DeleteFact(f) returned false")
 	}
 
-	bucket := d.FactsByName(f.Name)
+	bucket := d.FactsAsSliceWithName(f.Name)
 	if len(bucket) != 1 {
-		t.Fatalf("d.FactsByName length changed: got %d, want 1", len(bucket))
+		t.Fatalf("d.FactsAsSliceWithName length changed: got %d, want 1", len(bucket))
 	}
 	if bucket[0] == nil || !bucket[0].Equal(f) {
 		t.Errorf("d's bucket[0] was mutated by c's later AddFact + DeleteFact: got %v, want F(a)", bucket[0])

--- a/monitor/configuration_test.go
+++ b/monitor/configuration_test.go
@@ -220,10 +220,10 @@ func hasFact(c *monitor.Config, f *rule.Fact) bool {
 	return false
 }
 
-// TestCloneSourceMutationDoesNotCorruptClone guards the Fix 3
-// invariant: after c.Clone() returns d, ANY subsequent mutation on c
-// must not be observable in d. Before the fix Clone left
-// c.ownedBuckets unchanged, so c.DeleteFact would short-circuit
+// TestCloneSourceMutationDoesNotCorruptClone guards the symmetric
+// copy-on-write invariant: after c.Clone() returns d, ANY subsequent
+// mutation on c must not be observable in d. If Clone left
+// c.ownedBuckets unchanged, c.DeleteFact would short-circuit
 // ensureOwned and mutate the bucket array shared with d, corrupting
 // d's view of the deleted fact.
 func TestCloneSourceMutationDoesNotCorruptClone(t *testing.T) {
@@ -326,10 +326,9 @@ func TestCloneIsolatedAcrossSiblings(t *testing.T) {
 }
 
 // TestConfigStringDeterministic verifies String() output is independent
-// of the order facts were added. factsByName is a Go map and
-// String() previously iterated it directly, giving randomised output
-// across runs - the bug that made RuleApplication's fmt.Sprintf-based
-// dedup non-deterministic before this branch added RuleApplication.Hash.
+// of the order facts were added. factsByName is a Go map, so a naive
+// iteration would give randomised output across runs; String() must
+// sort for a stable rendering.
 func TestConfigStringDeterministic(t *testing.T) {
 	a := rule.NewFact("A", []term.Term{term.NewConstant("1")}, rule.LinearFact)
 	b := rule.NewFact("B", []term.Term{term.NewConstant("2")}, rule.LinearFact)

--- a/monitor/conflict_set.go
+++ b/monitor/conflict_set.go
@@ -551,6 +551,28 @@ func conflictSetFacts(facts []*rule.Fact, body []*rule.Fact) *bindingSet {
 	)
 }
 
+// conflictSetFactsForConfig is like conflictSetFacts but draws candidates
+// from c.factsByName. It builds the items slice from only the predicate
+// buckets a body pattern references, skipping facts whose predicate the
+// rule's LHS never mentions. For configs with thousands of unrelated
+// facts this keeps the conflict-set pre-pass O(|interesting facts|)
+// instead of O(|all facts|).
+func conflictSetFactsForConfig(c *Config, body []*rule.Fact) *bindingSet {
+	// Collect the distinct predicate names referenced by body patterns.
+	// Most rules have only a handful, so a small set suffices.
+	seen := make(map[string]struct{}, len(body))
+	var items []*rule.Fact
+	for _, p := range body {
+		name := p.Name
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		items = append(items, c.factsByName[name]...)
+	}
+	return conflictSetFacts(items, body)
+}
+
 // conflictSetTerms matches a sequence of term patterns against a set of seen terms.
 // It builds a local index by function name and orders patterns by selectivity.
 // Seen terms are not deduplicated (passed nil hash/equal): the seen set is

--- a/monitor/conflict_set.go
+++ b/monitor/conflict_set.go
@@ -321,13 +321,17 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 	var virtualItems []T
 	if hash != nil && equal != nil {
 		virtualItems = make([]T, 0, len(items))
-		// seenByKey: per (name, arity) key, hash -> list of virtual indices
-		// for the unique items already admitted under this key. New items
-		// hash-match against this; equal-match decides duplicate.
-		seenByKey := make(map[conflictKey]map[uint64][]int)
-		// dupCount[vIdx]: how many copies of the unique fact first seen at
-		// vIdx have been admitted so far. Capped at bodySlotCount[key].
-		dupCount := make(map[int]int)
+		// firstByKey[key][hash] is the virtual index of the FIRST item we
+		// admitted at that (key, hash). In the common case (no hash
+		// collisions across distinct items) this is the only structure
+		// we need. dupCount[vIdx] tracks how many copies of the unique
+		// fact first seen at vIdx have been admitted so far. extraByKey
+		// only allocates when a hash already has a non-equal item, to
+		// hold the additional virtual indices for distinct-but-colliding
+		// items.
+		firstByKey := make(map[conflictKey]map[uint64]int)
+		var dupCount map[int]int                        // lazy: most slotCaps are 1
+		var extraByKey map[conflictKey]map[uint64][]int // lazy: rare collisions
 
 		for _, item := range items {
 			if !indexable(item) {
@@ -337,39 +341,75 @@ func conflictSet[T Unifier[T]](items []T, body []T, indexable func(T) bool, name
 			key := conflictKey{name: name(item), arity: len(args(item))}
 			slotCap := bodySlotCount[key]
 			if slotCap == 0 {
-				// No body slot consumes this key. Pass through so the
-				// needAllIndices fallback can still see it.
+				// No body slot consumes this key.
 				virtualItems = append(virtualItems, item)
 				continue
 			}
 			h := hash(item)
-			bucketSeen := seenByKey[key]
-			if bucketSeen == nil {
-				bucketSeen = make(map[uint64][]int)
-				seenByKey[key] = bucketSeen
+			byHash := firstByKey[key]
+			if byHash == nil {
+				byHash = make(map[uint64]int)
+				firstByKey[key] = byHash
 			}
-			// Check whether this item duplicates an already-admitted unique.
+			firstIdx, hashSeen := byHash[h]
+			if !hashSeen {
+				// First time we see this hash at this key. Admit.
+				byHash[h] = len(virtualItems)
+				virtualItems = append(virtualItems, item)
+				continue
+			}
+			// Check whether this item duplicates the first one at this hash.
+			if equal(virtualItems[firstIdx], item) {
+				if dupCount == nil {
+					dupCount = make(map[int]int)
+				}
+				c := dupCount[firstIdx]
+				if c == 0 {
+					c = 1 // implicit count for the first admission
+				}
+				if c >= slotCap {
+					continue // at cap, drop
+				}
+				dupCount[firstIdx] = c + 1
+				virtualItems = append(virtualItems, item)
+				continue
+			}
+			// Hash collision with a different item. Check extraByKey
+			// for prior collisions; admit if none match.
+			if extraByKey == nil {
+				extraByKey = make(map[conflictKey]map[uint64][]int)
+			}
+			extras := extraByKey[key]
+			if extras == nil {
+				extras = make(map[uint64][]int)
+				extraByKey[key] = extras
+			}
 			matched := -1
-			for _, vIdx := range bucketSeen[h] {
+			for _, vIdx := range extras[h] {
 				if equal(virtualItems[vIdx], item) {
 					matched = vIdx
 					break
 				}
 			}
 			if matched >= 0 {
-				if dupCount[matched] >= slotCap {
-					// Already at slot cap: drop further copies.
+				if dupCount == nil {
+					dupCount = make(map[int]int)
+				}
+				c := dupCount[matched]
+				if c == 0 {
+					c = 1
+				}
+				if c >= slotCap {
 					continue
 				}
-				dupCount[matched]++
+				dupCount[matched] = c + 1
 				virtualItems = append(virtualItems, item)
 				continue
 			}
-			// New unique fact.
+			// Genuinely new collision-distinct item. Record and admit.
 			vNew := len(virtualItems)
+			extras[h] = append(extras[h], vNew)
 			virtualItems = append(virtualItems, item)
-			bucketSeen[h] = append(bucketSeen[h], vNew)
-			dupCount[vNew] = 1
 		}
 	} else {
 		virtualItems = items

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -259,10 +259,6 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 		var appliedTriggers []RuleApplication
 
 		for _, r := range m.triggerRules[aKey] {
-			if !canMatchLHS(c, m.requirements[r]) {
-				continue
-			}
-
 			next, err := m.handleTriggers(c, a, r)
 			if err != nil {
 				return nil, err
@@ -274,10 +270,6 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 		var appliedHints []RuleApplication
 
 		for _, r := range m.hintRules[aKey] {
-			if !canMatchLHS(c, m.requirements[r]) {
-				continue
-			}
-
 			next, err := m.handleHints(c, a, r)
 			if err != nil {
 				return nil, err
@@ -868,16 +860,6 @@ func checkWellformedness(rules []*rule.Rule) error {
 	}
 
 	return nil
-}
-
-func splitPairFirstName(t term.Term) string {
-	fn, _ := splitPair(t)
-
-	if fn == nil {
-		log.Fatalf("unexpected hint or trigger: %s", t)
-	}
-
-	return term.Must(term.AsFunction(fn)).Name
 }
 
 // splitPairSignature returns the (name, arity) of the first component of

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -65,11 +65,50 @@ type Monitor struct {
 	// It is indexed by the rules' hints and triggers.
 	rules map[string][]*rule.Rule
 
+	// requirements maps each rule to the per-predicate name -> count its
+	// LHS demands. The rule-applicability gate consults this to short-
+	// circuit conflictSetFacts when a config can't possibly satisfy the
+	// rule's LHS.
+	requirements map[*rule.Rule]map[string]int
+
 	// configs is the set of configurations that the monitor has.
 	configs *data.HashSet[*Config]
 
 	// stats includes the statistics of the monitor.
 	stats *Stats
+}
+
+// computeRequirements returns the per-predicate-name count of facts the
+// rule's LHS demands. A rule whose LHS asks for two instances of
+// State() and one of Out() has needCount{"State": 2, "Out": 1}.
+func computeRequirements(lhs []*rule.Fact) map[string]int {
+	if len(lhs) == 0 {
+		return nil
+	}
+	needCount := make(map[string]int, len(lhs))
+	for _, f := range lhs {
+		if f == nil {
+			continue
+		}
+		needCount[f.Name]++
+	}
+	return needCount
+}
+
+// canMatchLHS reports whether c could possibly satisfy r's LHS. False
+// means the conflictSetFacts call for (c, r) can be skipped entirely.
+// True is necessary but not sufficient: the binding/unification work
+// happens later.
+func canMatchLHS(c *Config, needCount map[string]int) bool {
+	if len(needCount) == 0 {
+		return true
+	}
+	for name, need := range needCount {
+		if c.CountByName(name) < need {
+			return false
+		}
+	}
+	return true
 }
 
 func NewMonitor(rules []*rule.Rule) (*Monitor, error) {
@@ -78,7 +117,10 @@ func NewMonitor(rules []*rule.Rule) (*Monitor, error) {
 	}
 
 	rulesMap := make(map[string][]*rule.Rule)
+	requirements := make(map[*rule.Rule]map[string]int, len(rules))
 	for _, r := range rules {
+		requirements[r] = computeRequirements(r.LHS)
+
 		if !r.HasHints() && !r.HasTriggers() {
 			rulesMap[""] = append(rulesMap[""], r)
 
@@ -91,9 +133,10 @@ func NewMonitor(rules []*rule.Rule) (*Monitor, error) {
 	}
 
 	return &Monitor{
-		rules:   rulesMap,
-		configs: data.NewHashSet(NewConfig()),
-		stats:   &Stats{},
+		rules:        rulesMap,
+		requirements: requirements,
+		configs:      data.NewHashSet(NewConfig()),
+		stats:        &Stats{},
 	}, nil
 }
 
@@ -129,8 +172,11 @@ func (m *Monitor) ProcessEvent(a term.Term) error {
 			if !r.HasTriggers() {
 				continue
 			}
+			if !canMatchLHS(c, m.requirements[r]) {
+				continue
+			}
 
-			next, err := handleTriggers(c, a, r, m.rules)
+			next, err := handleTriggers(c, a, r, m.rules, m.requirements)
 			if err != nil {
 				return err
 			}
@@ -144,8 +190,11 @@ func (m *Monitor) ProcessEvent(a term.Term) error {
 			if !r.HasHints() {
 				continue
 			}
+			if !canMatchLHS(c, m.requirements[r]) {
+				continue
+			}
 
-			next, err := handleHints(c, a, r, m.rules)
+			next, err := handleHints(c, a, r, m.rules, m.requirements)
 			if err != nil {
 				return err
 			}
@@ -253,10 +302,13 @@ func getUniqueBinding(matches []term.Term, target term.Term) (*term.Binding, err
 	return unique, nil
 }
 
-func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.Rule) (*data.HashSet[RuleApplication], error) {
+func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.Rule, requirements map[*rule.Rule]map[string]int) (*data.HashSet[RuleApplication], error) {
 	log.Tracef("handleTriggers(%s, %s, %s)\n\n", c, a, r.Name)
 
 	C := data.NewHashSet[RuleApplication]()
+	if !canMatchLHS(c, requirements[r]) {
+		return C, nil
+	}
 	for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
 		// Instantiate the triggers with the found binding.
 		// This ensures
@@ -290,7 +342,7 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 
 				// Check for applicable epsilon rules.
 				// At most one may exist.
-				e, err := handleEpsilon(d, rules)
+				e, err := handleEpsilon(d, rules, requirements)
 				if err != nil {
 					return nil, err
 				}
@@ -308,12 +360,15 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 	return C, nil
 }
 
-func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.Rule) (*data.HashSet[RuleApplication], error) {
+func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.Rule, requirements map[*rule.Rule]map[string]int) (*data.HashSet[RuleApplication], error) {
 	log.Tracef("handleHints(%s, %s, %s)\n\n", c, a, r.Name)
 
 	aName := splitPairFirstName(a)
 
 	C := data.NewHashSet[RuleApplication]()
+	if !canMatchLHS(c, requirements[r]) {
+		return C, nil
+	}
 	for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
 		// Instantiate the hints with the found binding.
 		// This ensures
@@ -347,7 +402,7 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 			if !rr.HasTriggers() {
 				continue
 			}
-			next, err := handleTriggers(d, g, rr, rules)
+			next, err := handleTriggers(d, g, rr, rules, requirements)
 			if err != nil {
 				return nil, err
 			}
@@ -369,11 +424,14 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 }
 
 // handleEpsilon handles rules without triggers or hints.
-func handleEpsilon(c *Config, rules map[string][]*rule.Rule) (*Config, error) {
+func handleEpsilon(c *Config, rules map[string][]*rule.Rule, requirements map[*rule.Rule]map[string]int) (*Config, error) {
 	log.Infof("\n\nhandleEpsilon()\n")
 	var C []*Config
 
 	for _, r := range rules[""] {
+		if !canMatchLHS(c, requirements[r]) {
+			continue
+		}
 		for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
 			log.Infof("epsilon rule %s is applicable\n  binding: %s", r.Name, b)
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -745,7 +745,7 @@ func (m *Monitor) ProcessEvents(events <-chan *TimedEvent, rewrite bool, pid int
 			if err != nil {
 				log.Warnf("\nfinal configurations (%d)\n", m.configs.Size())
 				for _, c := range m.configs.Values() {
-					for _, f := range c.facts {
+					for _, f := range c.Facts() {
 						log.Warnf("  %s\n", f.Name)
 					}
 				}
@@ -774,7 +774,7 @@ func (m *Monitor) ProcessEvents(events <-chan *TimedEvent, rewrite bool, pid int
 
 		log.Warnf("\nfinal configurations (%d)\n", m.configs.Size())
 		for _, c := range m.configs.Values() {
-			for _, f := range c.facts {
+			for _, f := range c.Facts() {
 				log.Warnf("  %s\n", f.Name)
 			}
 		}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -171,15 +171,31 @@ func NewMonitor(rules []*rule.Rule) (*Monitor, error) {
 			continue
 		}
 
+		// A rule may carry several triggers (or hints) with the same
+		// (name, arity) signature. Register it once per key: a single
+		// handleTriggers/handleHints invocation already considers every
+		// trigger/hint term of the rule, so a duplicate registration
+		// would repeat the identical applications and emit their
+		// actions twice.
 		if hasTriggers {
+			seenKeys := make(map[ruleKey]struct{}, len(r.Triggers()))
 			for _, t := range r.Triggers() {
 				k := ruleKeyForTerm(t)
+				if _, ok := seenKeys[k]; ok {
+					continue
+				}
+				seenKeys[k] = struct{}{}
 				triggerRules[k] = append(triggerRules[k], r)
 			}
 		}
 		if hasHints {
+			seenKeys := make(map[ruleKey]struct{}, len(r.Hints()))
 			for _, t := range r.Hints() {
 				k := ruleKeyForTerm(t)
+				if _, ok := seenKeys[k]; ok {
+					continue
+				}
+				seenKeys[k] = struct{}{}
 				hintRules[k] = append(hintRules[k], r)
 			}
 		}

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -154,14 +154,17 @@ type RuleApplication struct {
 	rule    *rule.Rule
 	binding *term.Binding
 	config  *Config
+	actions []*rule.Fact
 }
 
 // ProcessEvent consumes an event and performs the necessary monitoring actions.
-// It returns an error if there was an issue while consuming the event.
-func (m *Monitor) ProcessEvent(a term.Term) error {
+// It returns the action facts produced by each successful rule application
+// (one slice per RuleApplication) and an error if processing failed.
+func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 	log.Debugf("ProcessEvent(%s)\n", a)
 
 	updated := data.NewHashSet[*Config]()
+	var actions [][]*rule.Fact
 
 	aName := splitPairFirstName(a)
 
@@ -178,7 +181,7 @@ func (m *Monitor) ProcessEvent(a term.Term) error {
 
 			next, err := handleTriggers(c, a, r, m.rules, m.requirements)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			appliedTriggers = appliedTriggers.Union(next)
@@ -196,7 +199,7 @@ func (m *Monitor) ProcessEvent(a term.Term) error {
 
 			next, err := handleHints(c, a, r, m.rules, m.requirements)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			if appliedTriggers.Empty() {
@@ -223,6 +226,9 @@ func (m *Monitor) ProcessEvent(a term.Term) error {
 
 		appliedTriggers.Union(appliedHints).Iterate(func(t RuleApplication) bool {
 			updated.Add(t.config)
+			if len(t.actions) > 0 {
+				actions = append(actions, t.actions)
+			}
 
 			return true
 		})
@@ -241,12 +247,12 @@ func (m *Monitor) ProcessEvent(a term.Term) error {
 			}
 		}
 
-		return ErrNoApplicableRule
+		return nil, ErrNoApplicableRule
 	}
 
 	m.configs = updated
 
-	return nil
+	return actions, nil
 }
 
 // findPossibleEvents returns the events that are possible in each configuration.
@@ -329,7 +335,7 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 
 		if triggerBindings.Empty() {
 			log.Infof("rule %s is not applicable: missing triggers", r.Name)
-			C.Add(RuleApplication{r, bt, d})
+			C.Add(RuleApplication{r, bt, d, nil})
 
 			continue
 		}
@@ -337,17 +343,17 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 		for _, tb := range triggerBindings.Values() {
 			withTrigger := bt.Extend(tb)
 
-			if d, err := d.ApplyRule(r, withTrigger); err == nil {
+			if d2, acts, err := d.ApplyRule(r, withTrigger); err == nil {
 				log.Infof("rule %s is applicable\n  binding: %s", r.Name, withTrigger)
 
 				// Check for applicable epsilon rules.
 				// At most one may exist.
-				e, err := handleEpsilon(d, rules, requirements)
+				e, err := handleEpsilon(d2, rules, requirements)
 				if err != nil {
 					return nil, err
 				}
 
-				C.Add(RuleApplication{r, withTrigger, e})
+				C.Add(RuleApplication{r, withTrigger, e, acts})
 			} else if errors.Is(err, ErrRestrictionViolated) {
 				log.Infof("rule %s not applicable due to restriction: %v", r.Name, err)
 				continue
@@ -384,7 +390,7 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 
 		log.Infof("hint rule %s is applicable\n  binding: %s", r.Name, hb)
 
-		d, err := c.ApplyRule(r, hb)
+		d, hintActs, err := c.ApplyRule(r, hb)
 		if err != nil {
 			if errors.Is(err, ErrRestrictionViolated) {
 				log.Infof("hint rule %s not applicable due to restriction: %v", r.Name, err)
@@ -414,7 +420,12 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 		}
 
 		D.Iterate(func(t RuleApplication) bool {
-			C.Add(RuleApplication{r, hb, t.config})
+			// Concatenate hint actions and downstream trigger actions.
+			actions := hintActs
+			if len(t.actions) > 0 {
+				actions = append(actions, t.actions...)
+			}
+			C.Add(RuleApplication{r, hb, t.config, actions})
 
 			return true
 		})
@@ -435,7 +446,7 @@ func handleEpsilon(c *Config, rules map[string][]*rule.Rule, requirements map[*r
 		for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
 			log.Infof("epsilon rule %s is applicable\n  binding: %s", r.Name, b)
 
-			d, err := c.ApplyRule(r, b)
+			d, _, err := c.ApplyRule(r, b)
 			if err != nil {
 				return nil, err
 			}
@@ -604,7 +615,8 @@ func (m *Monitor) ProcessEvents(events <-chan *TimedEvent, rewrite bool, pid int
 
 			m.stats.LatenciesReceived = append(m.stats.LatenciesReceived, time.Since(time.Unix(0, event.Time)))
 
-			if err := m.ProcessEvent(event.Event); err != nil {
+			actions, err := m.ProcessEvent(event.Event)
+			if err != nil {
 				log.Warnf("\nfinal configurations (%d)\n", m.configs.Size())
 				for _, c := range m.configs.Values() {
 					for _, f := range c.facts {
@@ -621,17 +633,12 @@ func (m *Monitor) ProcessEvents(events <-chan *TimedEvent, rewrite bool, pid int
 			m.stats.LatenciesProcessed = append(m.stats.LatenciesProcessed, time.Since(time.Unix(0, event.Time)))
 
 			if rewrite {
-				for _, c := range m.configs.Values() {
-					select {
-					case p := <-c.queue:
-						for _, f := range p {
-							if r := getRewriteTerm(f); r != nil {
-								fr := term.Must(term.AsFunction(r))
-								out <- &TimedEvent{Time: event.Time, Event: fr}
-							}
+				for _, group := range actions {
+					for _, f := range group {
+						if r := getRewriteTerm(f); r != nil {
+							fr := term.Must(term.AsFunction(r))
+							out <- &TimedEvent{Time: event.Time, Event: fr}
 						}
-					default:
-						// No output to process
 					}
 				}
 			} else {

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -315,18 +315,41 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 	if !canMatchLHS(c, requirements[r]) {
 		return C, nil
 	}
-	for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
-		// Instantiate the triggers with the found binding.
-		// This ensures
-		//   1. The binding found is compatible with b.
-		//   2. The triggers can be evaluated and the functions they contain be evaluated.
-		instTriggers := term.Terms(r.Triggers()).Subst(b)
 
-		u, err := getUniqueBinding(instTriggers, a)
-		if err != nil {
-			continue
+	rawTriggers := r.Triggers()
+
+	// Try to extract a trigger binding from the event first. When this
+	// succeeds, shared variables narrow the LHS fact search from O(N)
+	// to O(1). Falls back to the original O(N) approach when the raw
+	// trigger contains format expressions with functions of unbound
+	// variables that cannot be evaluated without LHS-derived bindings.
+	triggerBinding, triggerErr := getUniqueBinding(rawTriggers, a)
+
+	var lhsPatterns []*rule.Fact
+	if triggerErr == nil {
+		lhsPatterns = make([]*rule.Fact, len(r.LHS))
+		for i, f := range r.LHS {
+			lhsPatterns[i] = f.Subst(triggerBinding)
 		}
-		bt := b.Extend(u)
+	} else {
+		lhsPatterns = r.LHS
+	}
+
+	for _, b := range conflictSetFacts(c.facts, lhsPatterns).Values() {
+		var bt *term.Binding
+		if triggerErr == nil {
+			bt = triggerBinding.Extend(b)
+		} else {
+			// Fallback: match trigger instantiated with LHS binding.
+			instTriggers := term.Terms(rawTriggers).Subst(b)
+			u, err := getUniqueBinding(instTriggers, a)
+			if err != nil {
+				continue
+			}
+			bt = b.Extend(u)
+		}
+
+		instTriggers := term.Terms(rawTriggers).Subst(bt)
 
 		d := c.Clone()
 		d.AddSeen(a.Subst(bt))
@@ -375,18 +398,36 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 	if !canMatchLHS(c, requirements[r]) {
 		return C, nil
 	}
-	for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
-		// Instantiate the hints with the found binding.
-		// This ensures
-		//   1. The binding found is compatible with b.
-		//   2. The hints can be evaluated and the functions they contain be evaluated.
-		instHints := term.Terms(r.Hints()).Subst(b)
 
-		u, err := getUniqueBinding(instHints, a)
-		if err != nil {
-			continue
+	rawHints := r.Hints()
+
+	// Mirror handleTriggers: extract hint binding from the event first
+	// to narrow the LHS fact search; fall back to the original O(N)
+	// approach when hint evaluation requires LHS-derived bindings.
+	hintBinding, hintErr := getUniqueBinding(rawHints, a)
+
+	var lhsPatterns []*rule.Fact
+	if hintErr == nil {
+		lhsPatterns = make([]*rule.Fact, len(r.LHS))
+		for i, f := range r.LHS {
+			lhsPatterns[i] = f.Subst(hintBinding)
 		}
-		hb := b.Extend(u)
+	} else {
+		lhsPatterns = r.LHS
+	}
+
+	for _, b := range conflictSetFacts(c.facts, lhsPatterns).Values() {
+		var hb *term.Binding
+		if hintErr == nil {
+			hb = hintBinding.Extend(b)
+		} else {
+			instHints := term.Terms(rawHints).Subst(b)
+			u, err := getUniqueBinding(instHints, a)
+			if err != nil {
+				continue
+			}
+			hb = b.Extend(u)
+		}
 
 		log.Infof("hint rule %s is applicable\n  binding: %s", r.Name, hb)
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -185,6 +185,22 @@ func (m *Monitor) Stats() *Stats {
 	return m.stats
 }
 
+// RuleApplication records one rule firing during a ProcessEvent call:
+// the rule that ran, the binding that produced it, the resulting
+// configuration, and the action facts emitted (forwarded to the
+// rewrite output when the monitor runs in rewrite mode).
+//
+// RuleApplication has no Hash or Equal method by design. It is
+// collected into plain []RuleApplication slices throughout the
+// monitor; structural deduplication happens later at the *Config
+// boundary (HashSet[*Config]) where it has well-defined meaning.
+// Trying to dedup at the RuleApplication level proved fragile in
+// review: every observable difference between two applications
+// (rule pointer, binding, resulting config, action list) would need
+// to be folded into a 64-bit hash with no collision fallback, and
+// each round of review found another field that needed inclusion.
+// Treating applications as a sequence instead of a set sidesteps
+// the entire identity-encoding problem.
 type RuleApplication struct {
 	rule    *rule.Rule
 	binding *term.Binding
@@ -204,7 +220,7 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 	aKey := ruleKeyForTerm(a)
 
 	for _, c := range m.configs.Values() {
-		appliedTriggers := data.NewHashSet[RuleApplication]()
+		var appliedTriggers []RuleApplication
 
 		for _, r := range m.triggerRules[aKey] {
 			if !canMatchLHS(c, m.requirements[r]) {
@@ -216,10 +232,10 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 				return nil, err
 			}
 
-			appliedTriggers = appliedTriggers.Union(next)
+			appliedTriggers = append(appliedTriggers, next...)
 		}
 
-		appliedHints := data.NewHashSet[RuleApplication]()
+		var appliedHints []RuleApplication
 
 		for _, r := range m.hintRules[aKey] {
 			if !canMatchLHS(c, m.requirements[r]) {
@@ -231,36 +247,53 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 				return nil, err
 			}
 
-			if appliedTriggers.Empty() {
-				appliedHints = appliedHints.Union(next)
+			if len(appliedTriggers) == 0 {
+				appliedHints = append(appliedHints, next...)
 
 				continue
 			}
 
-			appliedTriggers.Iterate(func(t RuleApplication) bool {
-				next.Iterate(func(h RuleApplication) bool {
-					// If r is not a start rule of an applicable trigger
-					// or the binding of the hint rule is different from the trigger rule,
-					// then add the configuration.
+			// Replicate the original HashSet-based filter as a slice
+			// append with semantically-equivalent dedup.
+			//
+			// Original semantics: for each (t, h) pair add h iff
+			// NOT(r is a start-rule of t.rule AND t.binding == h.binding).
+			// With HashSet, repeated Adds of the same h collapsed; a
+			// single h was kept iff AT LEAST ONE t in appliedTriggers
+			// passed the predicate.
+			//
+			// Equivalently: h is suppressed iff FOR ALL t,
+			//   IsStartRuleOf(r, t.rule) AND t.binding.Equal(h.binding).
+			// We keep h otherwise. Each surviving h is appended once.
+			for _, h := range next {
+				suppress := true
+				for _, t := range appliedTriggers {
 					if !rule.IsStartRuleOf(r, t.rule) || !t.binding.Equal(h.binding) {
-						appliedHints.Add(h)
+						suppress = false
+						break
 					}
-
-					return true
-				})
-
-				return true
-			})
+				}
+				if !suppress {
+					appliedHints = append(appliedHints, h)
+				}
+			}
 		}
 
-		appliedTriggers.Union(appliedHints).Iterate(func(t RuleApplication) bool {
+		// Concatenated walk over the per-event applications. updated.Add
+		// dedups *Config structurally; actions are forwarded in order
+		// as the rewrite consumer expects.
+		for _, t := range appliedTriggers {
 			updated.Add(t.config)
 			if len(t.actions) > 0 {
 				actions = append(actions, t.actions)
 			}
-
-			return true
-		})
+		}
+		for _, t := range appliedHints {
+			updated.Add(t.config)
+			if len(t.actions) > 0 {
+				actions = append(actions, t.actions)
+			}
+		}
 	}
 
 	if updated.Size() > 1 {
@@ -365,13 +398,13 @@ func getUniqueBinding(matches []term.Term, target term.Term) (*term.Binding, err
 	return unique, nil
 }
 
-func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) (*data.HashSet[RuleApplication], error) {
+func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) ([]RuleApplication, error) {
 	log.Tracef("handleTriggers(%s, %s, %s)\n\n", c, a, r.Name)
 
-	C := data.NewHashSet[RuleApplication]()
 	if !canMatchLHS(c, m.requirements[r]) {
-		return C, nil
+		return nil, nil
 	}
+	var C []RuleApplication
 
 	rawTriggers := r.Triggers()
 
@@ -415,7 +448,7 @@ func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) (*data.Ha
 
 		if triggerBindings.Empty() {
 			log.Infof("rule %s is not applicable: missing triggers", r.Name)
-			C.Add(RuleApplication{r, bt, d, nil})
+			C = append(C, RuleApplication{rule: r, binding: bt, config: d, actions: nil})
 
 			continue
 		}
@@ -435,7 +468,7 @@ func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) (*data.Ha
 					return nil, err
 				}
 
-				C.Add(RuleApplication{r, withTrigger, e, concatActions(acts, epsActs)})
+				C = append(C, RuleApplication{rule: r, binding: withTrigger, config: e, actions: concatActions(acts, epsActs)})
 			} else if errors.Is(err, ErrRestrictionViolated) {
 				log.Infof("rule %s not applicable due to restriction: %v", r.Name, err)
 				continue
@@ -448,13 +481,13 @@ func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) (*data.Ha
 	return C, nil
 }
 
-func (m *Monitor) handleHints(c *Config, a term.Term, r *rule.Rule) (*data.HashSet[RuleApplication], error) {
+func (m *Monitor) handleHints(c *Config, a term.Term, r *rule.Rule) ([]RuleApplication, error) {
 	log.Tracef("handleHints(%s, %s, %s)\n\n", c, a, r.Name)
 
-	C := data.NewHashSet[RuleApplication]()
 	if !canMatchLHS(c, m.requirements[r]) {
-		return C, nil
+		return nil, nil
 	}
+	var C []RuleApplication
 
 	rawHints := r.Hints()
 
@@ -501,28 +534,26 @@ func (m *Monitor) handleHints(c *Config, a term.Term, r *rule.Rule) (*data.HashS
 		g := a.Subst(hb)
 		gKey := ruleKeyForTerm(g)
 
-		D := data.NewHashSet[RuleApplication]()
+		var D []RuleApplication
 		for _, rr := range m.triggerRules[gKey] {
 			next, err := m.handleTriggers(d, g, rr)
 			if err != nil {
 				return nil, err
 			}
-			D = D.Union(next)
+			D = append(D, next...)
 		}
 
-		if D.Size() == 0 {
+		if len(D) == 0 {
 			return nil, fmt.Errorf("no applicable rule found after accepting hint %s", g)
 		}
 
-		D.Iterate(func(t RuleApplication) bool {
+		for _, t := range D {
 			// Concatenate hint actions and downstream trigger actions.
 			// concatActions allocates only when both sides are non-empty,
 			// so the common single-source case stays alloc-free and we
 			// avoid aliasing hintActs across iterations.
-			C.Add(RuleApplication{r, hb, t.config, concatActions(hintActs, t.actions)})
-
-			return true
-		})
+			C = append(C, RuleApplication{rule: r, binding: hb, config: t.config, actions: concatActions(hintActs, t.actions)})
+		}
 	}
 
 	return C, nil

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -103,14 +103,13 @@ type Monitor struct {
 	// collision rate is zero.
 	//
 	// This is a workload-level guarantee, not a structural one. A
-	// configSet earlier in the branch added Config.Equal-based
-	// collision safety on top of hash bucketing, but the resulting
-	// 30-100% wall-time regression on signal-large was unacceptable
-	// for a property that never fired on the measured workloads. If
-	// either (a) a future workload exhibits hash collisions or
-	// (b) future infrastructure (term interning, fact pools) reduces
-	// the per-Equal cost to neutral, revisit by reintroducing the
-	// configSet container.
+	// container adding Config.Equal-based collision safety on top of
+	// hash bucketing was evaluated, but the resulting 30-100%
+	// wall-time regression on signal-large was unacceptable for a
+	// property that never fired on the measured workloads. If either
+	// (a) a future workload exhibits hash collisions or (b) future
+	// infrastructure (term interning, fact pools) reduces the
+	// per-Equal cost to neutral, revisit an Equal-checking container.
 	configs *data.HashSet[*Config]
 
 	// stats includes the statistics of the monitor.
@@ -226,17 +225,12 @@ func (m *Monitor) Stats() *Stats {
 // configuration, and the action facts emitted (forwarded to the
 // rewrite output when the monitor runs in rewrite mode).
 //
-// RuleApplication has no Hash or Equal method by design. It is
-// collected into plain []RuleApplication slices throughout the
-// monitor; structural deduplication happens later at the *Config
-// boundary (HashSet[*Config]) where it has well-defined meaning.
-// Trying to dedup at the RuleApplication level proved fragile in
-// review: every observable difference between two applications
-// (rule pointer, binding, resulting config, action list) would need
-// to be folded into a 64-bit hash with no collision fallback, and
-// each round of review found another field that needed inclusion.
-// Treating applications as a sequence instead of a set sidesteps
-// the entire identity-encoding problem.
+// RuleApplication has no Hash or Equal by design: applications are
+// collected as plain slices, and deduplication happens only at the
+// *Config boundary (HashSet[*Config]), where structural identity is
+// well defined. Deduplicating applications themselves would have to
+// fold every observable field (rule, binding, config, action list)
+// into a 64-bit hash with no collision fallback.
 type RuleApplication struct {
 	rule    *rule.Rule
 	binding *term.Binding

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -91,6 +91,26 @@ type Monitor struct {
 	requirements map[*rule.Rule]map[string]int
 
 	// configs is the set of configurations that the monitor has.
+	//
+	// Dedup semantics: data.HashSet keys solely by Config.Hash() with
+	// no Equal fallback (data/hashmap.go), so two configurations that
+	// happen to collide on Hash() will silently merge here. The
+	// monitor relies on Config.Hash being multiplicity-preserving
+	// (sum-based with splitmix64 mixing, see configuration.go) so
+	// trivially-distinct configurations (e.g. differing only in fact
+	// multiplicity) cannot collide by construction. For all measured
+	// workloads (signal-large, wireguard) the empirical genuine-
+	// collision rate is zero.
+	//
+	// This is a workload-level guarantee, not a structural one. A
+	// configSet earlier in the branch added Config.Equal-based
+	// collision safety on top of hash bucketing, but the resulting
+	// 30-100% wall-time regression on signal-large was unacceptable
+	// for a property that never fired on the measured workloads. If
+	// either (a) a future workload exhibits hash collisions or
+	// (b) future infrastructure (term interning, fact pools) reduces
+	// the per-Equal cost to neutral, revisit by reintroducing the
+	// configSet container.
 	configs *data.HashSet[*Config]
 
 	// stats includes the statistics of the monitor.

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -59,11 +59,30 @@ type Unifier[T any] interface {
 	Subst(b *term.Binding) T
 }
 
+// ruleKey identifies the predicate-name + arity an event term carries.
+// Splitting trigger and hint rule dispatch by (name, arity) lets us skip
+// the HasTriggers/HasHints filter in the hot loop and avoids visiting
+// rules that pattern-match the same name with a different arity.
+type ruleKey struct {
+	name  string
+	arity int
+}
+
 // Monitor is a monitor that processes events according to a set of rules.
 type Monitor struct {
-	// rules is the set of rules that the monitor uses.
-	// It is indexed by the rules' hints and triggers.
-	rules map[string][]*rule.Rule
+	// triggerRules maps event (name, arity) to rules whose triggers
+	// contain a term with that signature. Pre-filtered so hot-loop
+	// callers don't repeat HasTriggers().
+	triggerRules map[ruleKey][]*rule.Rule
+
+	// hintRules maps event (name, arity) to rules whose hints contain a
+	// term with that signature. Pre-filtered so hot-loop callers don't
+	// repeat HasHints().
+	hintRules map[ruleKey][]*rule.Rule
+
+	// epsilonRules are rules without triggers or hints, applied
+	// directly to the configuration.
+	epsilonRules []*rule.Rule
 
 	// requirements maps each rule to the per-predicate name -> count its
 	// LHS demands. The rule-applicability gate consults this to short-
@@ -116,24 +135,40 @@ func NewMonitor(rules []*rule.Rule) (*Monitor, error) {
 		return nil, err
 	}
 
-	rulesMap := make(map[string][]*rule.Rule)
+	triggerRules := make(map[ruleKey][]*rule.Rule)
+	hintRules := make(map[ruleKey][]*rule.Rule)
+	var epsilonRules []*rule.Rule
 	requirements := make(map[*rule.Rule]map[string]int, len(rules))
+
 	for _, r := range rules {
 		requirements[r] = computeRequirements(r.LHS)
 
-		if !r.HasHints() && !r.HasTriggers() {
-			rulesMap[""] = append(rulesMap[""], r)
+		hasTriggers := r.HasTriggers()
+		hasHints := r.HasHints()
 
+		if !hasTriggers && !hasHints {
+			epsilonRules = append(epsilonRules, r)
 			continue
 		}
 
-		for _, t := range append(r.Hints(), r.Triggers()...) {
-			rulesMap[splitPairFirstName(t)] = append(rulesMap[splitPairFirstName(t)], r)
+		if hasTriggers {
+			for _, t := range r.Triggers() {
+				k := ruleKeyForTerm(t)
+				triggerRules[k] = append(triggerRules[k], r)
+			}
+		}
+		if hasHints {
+			for _, t := range r.Hints() {
+				k := ruleKeyForTerm(t)
+				hintRules[k] = append(hintRules[k], r)
+			}
 		}
 	}
 
 	return &Monitor{
-		rules:        rulesMap,
+		triggerRules: triggerRules,
+		hintRules:    hintRules,
+		epsilonRules: epsilonRules,
 		requirements: requirements,
 		configs:      data.NewHashSet(NewConfig()),
 		stats:        &Stats{},
@@ -166,20 +201,17 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 	updated := data.NewHashSet[*Config]()
 	var actions [][]*rule.Fact
 
-	aName := splitPairFirstName(a)
+	aKey := ruleKeyForTerm(a)
 
 	for _, c := range m.configs.Values() {
 		appliedTriggers := data.NewHashSet[RuleApplication]()
 
-		for _, r := range m.rules[aName] {
-			if !r.HasTriggers() {
-				continue
-			}
+		for _, r := range m.triggerRules[aKey] {
 			if !canMatchLHS(c, m.requirements[r]) {
 				continue
 			}
 
-			next, err := handleTriggers(c, a, r, m.rules, m.requirements)
+			next, err := m.handleTriggers(c, a, r)
 			if err != nil {
 				return nil, err
 			}
@@ -189,15 +221,12 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 
 		appliedHints := data.NewHashSet[RuleApplication]()
 
-		for _, r := range m.rules[aName] {
-			if !r.HasHints() {
-				continue
-			}
+		for _, r := range m.hintRules[aKey] {
 			if !canMatchLHS(c, m.requirements[r]) {
 				continue
 			}
 
-			next, err := handleHints(c, a, r, m.rules, m.requirements)
+			next, err := m.handleHints(c, a, r)
 			if err != nil {
 				return nil, err
 			}
@@ -259,15 +288,43 @@ func (m *Monitor) ProcessEvent(a term.Term) ([][]*rule.Fact, error) {
 func (m *Monitor) findPossibleEvents() [][]term.Term {
 	events := make([][]term.Term, m.configs.Size())
 
+	// Collect each rule once across the three buckets (a rule may live in
+	// multiple keys of triggerRules / hintRules).
+	seen := make(map[*rule.Rule]struct{})
+	var allRules []*rule.Rule
+	for _, rs := range m.triggerRules {
+		for _, r := range rs {
+			if _, ok := seen[r]; ok {
+				continue
+			}
+			seen[r] = struct{}{}
+			allRules = append(allRules, r)
+		}
+	}
+	for _, rs := range m.hintRules {
+		for _, r := range rs {
+			if _, ok := seen[r]; ok {
+				continue
+			}
+			seen[r] = struct{}{}
+			allRules = append(allRules, r)
+		}
+	}
+	for _, r := range m.epsilonRules {
+		if _, ok := seen[r]; ok {
+			continue
+		}
+		seen[r] = struct{}{}
+		allRules = append(allRules, r)
+	}
+
 	for i, c := range m.configs.Values() {
 		var e []term.Term
-		for _, rs := range m.rules {
-			for _, r := range rs {
-				for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
-					s := r.Subst(b)
-					e = append(e, s.Hints()...)
-					e = append(e, s.Triggers()...)
-				}
+		for _, r := range allRules {
+			for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
+				s := r.Subst(b)
+				e = append(e, s.Hints()...)
+				e = append(e, s.Triggers()...)
 			}
 		}
 
@@ -308,11 +365,11 @@ func getUniqueBinding(matches []term.Term, target term.Term) (*term.Binding, err
 	return unique, nil
 }
 
-func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.Rule, requirements map[*rule.Rule]map[string]int) (*data.HashSet[RuleApplication], error) {
+func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) (*data.HashSet[RuleApplication], error) {
 	log.Tracef("handleTriggers(%s, %s, %s)\n\n", c, a, r.Name)
 
 	C := data.NewHashSet[RuleApplication]()
-	if !canMatchLHS(c, requirements[r]) {
+	if !canMatchLHS(c, m.requirements[r]) {
 		return C, nil
 	}
 
@@ -370,13 +427,15 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 				log.Infof("rule %s is applicable\n  binding: %s", r.Name, withTrigger)
 
 				// Check for applicable epsilon rules.
-				// At most one may exist.
-				e, err := handleEpsilon(d2, rules, requirements)
+				// At most one may exist. Epsilon actions (if any) are
+				// concatenated onto the trigger's so PPEvent rewrites
+				// emitted by epsilon rules reach the rewrite output.
+				e, epsActs, err := m.handleEpsilon(d2)
 				if err != nil {
 					return nil, err
 				}
 
-				C.Add(RuleApplication{r, withTrigger, e, acts})
+				C.Add(RuleApplication{r, withTrigger, e, concatActions(acts, epsActs)})
 			} else if errors.Is(err, ErrRestrictionViolated) {
 				log.Infof("rule %s not applicable due to restriction: %v", r.Name, err)
 				continue
@@ -389,13 +448,11 @@ func handleTriggers(c *Config, a term.Term, r *rule.Rule, rules map[string][]*ru
 	return C, nil
 }
 
-func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.Rule, requirements map[*rule.Rule]map[string]int) (*data.HashSet[RuleApplication], error) {
+func (m *Monitor) handleHints(c *Config, a term.Term, r *rule.Rule) (*data.HashSet[RuleApplication], error) {
 	log.Tracef("handleHints(%s, %s, %s)\n\n", c, a, r.Name)
 
-	aName := splitPairFirstName(a)
-
 	C := data.NewHashSet[RuleApplication]()
-	if !canMatchLHS(c, requirements[r]) {
+	if !canMatchLHS(c, m.requirements[r]) {
 		return C, nil
 	}
 
@@ -442,14 +499,11 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 
 		// After applying the hint rule, we have to consume the event again with a trigger rule.
 		g := a.Subst(hb)
+		gKey := ruleKeyForTerm(g)
 
 		D := data.NewHashSet[RuleApplication]()
-		for _, rr := range rules[aName] {
-			// Skip rules without triggers - we only want to apply trigger rules here
-			if !rr.HasTriggers() {
-				continue
-			}
-			next, err := handleTriggers(d, g, rr, rules, requirements)
+		for _, rr := range m.triggerRules[gKey] {
+			next, err := m.handleTriggers(d, g, rr)
 			if err != nil {
 				return nil, err
 			}
@@ -462,11 +516,10 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 
 		D.Iterate(func(t RuleApplication) bool {
 			// Concatenate hint actions and downstream trigger actions.
-			actions := hintActs
-			if len(t.actions) > 0 {
-				actions = append(actions, t.actions...)
-			}
-			C.Add(RuleApplication{r, hb, t.config, actions})
+			// concatActions allocates only when both sides are non-empty,
+			// so the common single-source case stays alloc-free and we
+			// avoid aliasing hintActs across iterations.
+			C.Add(RuleApplication{r, hb, t.config, concatActions(hintActs, t.actions)})
 
 			return true
 		})
@@ -475,37 +528,69 @@ func handleHints(c *Config, a term.Term, r *rule.Rule, rules map[string][]*rule.
 	return C, nil
 }
 
-// handleEpsilon handles rules without triggers or hints.
-func handleEpsilon(c *Config, rules map[string][]*rule.Rule, requirements map[*rule.Rule]map[string]int) (*Config, error) {
+// handleEpsilon handles rules without triggers or hints. At most one
+// epsilon rule may apply; if more than one matches the result is an
+// error.
+//
+// Returns (resultConfig, epsilonActions, error). epsilonActions are the
+// Act facts produced by the epsilon rule application, or nil when no
+// epsilon rule fires. Callers must concatenate these onto the actions
+// they collected from the preceding trigger/hint application so that
+// PPEvent rewrites emitted by epsilon rules are forwarded to the
+// rewrite output channel.
+func (m *Monitor) handleEpsilon(c *Config) (*Config, []*rule.Fact, error) {
 	log.Infof("\n\nhandleEpsilon()\n")
-	var C []*Config
 
-	for _, r := range rules[""] {
-		if !canMatchLHS(c, requirements[r]) {
+	// Track every applied (config, actions) pair so the "exactly one"
+	// invariant is enforced at the end. In the success case there is at
+	// most one entry; the slice avoids special-casing for early-exit.
+	var configs []*Config
+	var actions [][]*rule.Fact
+
+	for _, r := range m.epsilonRules {
+		if !canMatchLHS(c, m.requirements[r]) {
 			continue
 		}
 		for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
 			log.Infof("epsilon rule %s is applicable\n  binding: %s", r.Name, b)
 
-			d, _, err := c.ApplyRule(r, b)
+			d, acts, err := c.ApplyRule(r, b)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 
-			C = append(C, d)
+			configs = append(configs, d)
+			actions = append(actions, acts)
 		}
 	}
 
-	if len(C) > 1 {
-		return nil, errors.New("multiple applicable epsilon rules found")
+	if len(configs) > 1 {
+		return nil, nil, errors.New("multiple applicable epsilon rules found")
 	}
 
-	// If no epsilon rule is applicable, return the original config.
-	if len(C) == 0 {
-		return c, nil
+	// If no epsilon rule is applicable, return the original config and
+	// no actions.
+	if len(configs) == 0 {
+		return c, nil, nil
 	}
 
-	return C[0], nil
+	return configs[0], actions[0], nil
+}
+
+// concatActions returns the concatenation of a and b without aliasing
+// a's backing array. Returns the non-nil slice unchanged when the
+// other is empty so the common single-source case does not allocate.
+func concatActions(a, b []*rule.Fact) []*rule.Fact {
+	if len(b) == 0 {
+		return a
+	}
+	if len(a) == 0 {
+		return b
+	}
+	out := make([]*rule.Fact, 0, len(a)+len(b))
+	out = append(out, a...)
+	out = append(out, b...)
+	return out
 }
 
 //
@@ -726,4 +811,23 @@ func splitPairFirstName(t term.Term) string {
 	}
 
 	return term.Must(term.AsFunction(fn)).Name
+}
+
+// splitPairSignature returns the (name, arity) of the first component of
+// a hint/trigger pair. Used to bucket rules into triggerRules / hintRules
+// so dispatch is by (name, arity) rather than name only.
+func splitPairSignature(t term.Term) (string, int) {
+	fn, _ := splitPair(t)
+	if fn == nil {
+		log.Fatalf("unexpected hint or trigger: %s", t)
+	}
+	parsed := term.Must(term.AsFunction(fn))
+	return parsed.Name, len(parsed.Args)
+}
+
+// ruleKeyForTerm returns the ruleKey of the first component of a
+// hint/trigger pair.
+func ruleKeyForTerm(t term.Term) ruleKey {
+	name, arity := splitPairSignature(t)
+	return ruleKey{name: name, arity: arity}
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -321,7 +321,7 @@ func (m *Monitor) findPossibleEvents() [][]term.Term {
 	for i, c := range m.configs.Values() {
 		var e []term.Term
 		for _, r := range allRules {
-			for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
+			for _, b := range conflictSetFactsForConfig(c, r.LHS).Values() {
 				s := r.Subst(b)
 				e = append(e, s.Hints()...)
 				e = append(e, s.Triggers()...)
@@ -392,7 +392,7 @@ func (m *Monitor) handleTriggers(c *Config, a term.Term, r *rule.Rule) (*data.Ha
 		lhsPatterns = r.LHS
 	}
 
-	for _, b := range conflictSetFacts(c.facts, lhsPatterns).Values() {
+	for _, b := range conflictSetFactsForConfig(c, lhsPatterns).Values() {
 		var bt *term.Binding
 		if triggerErr == nil {
 			bt = triggerBinding.Extend(b)
@@ -473,7 +473,7 @@ func (m *Monitor) handleHints(c *Config, a term.Term, r *rule.Rule) (*data.HashS
 		lhsPatterns = r.LHS
 	}
 
-	for _, b := range conflictSetFacts(c.facts, lhsPatterns).Values() {
+	for _, b := range conflictSetFactsForConfig(c, lhsPatterns).Values() {
 		var hb *term.Binding
 		if hintErr == nil {
 			hb = hintBinding.Extend(b)
@@ -551,7 +551,7 @@ func (m *Monitor) handleEpsilon(c *Config) (*Config, []*rule.Fact, error) {
 		if !canMatchLHS(c, m.requirements[r]) {
 			continue
 		}
-		for _, b := range conflictSetFacts(c.facts, r.LHS).Values() {
+		for _, b := range conflictSetFactsForConfig(c, r.LHS).Values() {
 			log.Infof("epsilon rule %s is applicable\n  binding: %s", r.Name, b)
 
 			d, acts, err := c.ApplyRule(r, b)

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -19,6 +19,7 @@
 package monitor_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/specmon/specmon/monitor"
@@ -233,4 +234,104 @@ func TestMonitorRestrictionViolation(t *testing.T) {
 	}
 
 	t.Logf("Test passed: Rule A succeeded, Rule B failed due to restriction violation")
+}
+
+// TestMonitorTriggerAnchoredToCurrentEvent pins the trigger-anchoring
+// semantics: every rule application performed while processing event a
+// must consume an instance of a itself. A buffered seen-event may only
+// fill the REMAINING trigger slots of a multi-trigger rule; it can
+// never supply the binding for the slot the current event matched.
+//
+// Scenario: R1 buffers go-events (its done-trigger never arrives). R2
+// consumes Gate() on <go, x>, where x occurs only in the trigger. The
+// trace buffers <go,'1'> while R2 is inapplicable (no Gate), creates
+// Gate(), then sends <go,'2'>.
+//
+// Exactly two configurations must result:
+//
+//	{ [Gate()]     | seen: <go,'1'>, <go,'2'> }  (R1 buffered <go,'2'>)
+//	{ [State('2')] | seen: <go,'1'> }            (R2 fired on <go,'2'>)
+//
+// A configuration containing State('1') -- R2 fired by binding x from
+// the buffered <go,'1'> instead of the arriving event -- is invalid
+// and must be unreachable. (Matching the trigger patterns against the
+// seen set with the event binding left open reintroduces it.)
+func TestMonitorTriggerAnchoredToCurrentEvent(t *testing.T) {
+	pairEv := func(name string, arg term.Term) *term.Function {
+		return term.NewFunction("pair", []term.Term{
+			term.NewFunction(name, []term.Term{}), arg,
+		})
+	}
+
+	r1 := &rule.Rule{
+		Name: "R1", LHS: []*rule.Fact{}, RHS: []*rule.Fact{},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{Value: []term.Term{
+				pairEv("go", term.NewVariable("y")),
+				pairEv("done", term.NewVariable("y")),
+			}},
+		},
+	}
+	r2 := &rule.Rule{
+		Name: "R2",
+		LHS:  []*rule.Fact{rule.NewFact("Gate", []term.Term{}, rule.LinearFact)},
+		RHS:  []*rule.Fact{rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact)},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{Value: []term.Term{
+				pairEv("go", term.NewVariable("x")),
+			}},
+		},
+	}
+	r3 := &rule.Rule{
+		Name: "R3", LHS: []*rule.Fact{},
+		RHS: []*rule.Fact{rule.NewFact("Gate", []term.Term{}, rule.LinearFact)},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{Value: []term.Term{
+				pairEv("mk", term.NewVariable("z")),
+			}},
+		},
+	}
+
+	mon, err := monitor.NewMonitor([]*rule.Rule{r1, r2, r3})
+	if err != nil {
+		t.Fatalf("NewMonitor: %v", err)
+	}
+	step := func(name, val string) {
+		if _, err := mon.ProcessEvent(pairEv(name, term.NewConstant(val))); err != nil {
+			t.Fatalf("ProcessEvent(%s,%s): %v", name, val, err)
+		}
+	}
+
+	step("go", "1")
+	step("mk", "0")
+	step("go", "2")
+
+	configs := mon.Configs()
+	if len(configs) != 2 {
+		for i, c := range configs {
+			t.Logf("config %d: %s", i, c)
+		}
+		t.Fatalf("expected exactly 2 configurations, got %d", len(configs))
+	}
+
+	var sawFired, sawBuffered bool
+	for _, c := range configs {
+		s := c.String()
+		if strings.Contains(s, "State('1')") {
+			t.Errorf("invalid configuration reached: R2 bound its trigger from the buffered <go,'1'>: %s", s)
+		}
+		switch {
+		case strings.Contains(s, "State('2')") && strings.Contains(s, "<go(), '1'>"):
+			sawFired = true
+		case strings.Contains(s, "Gate()") &&
+			strings.Contains(s, "<go(), '1'>") && strings.Contains(s, "<go(), '2'>"):
+			sawBuffered = true
+		}
+	}
+	if !sawFired {
+		t.Errorf("missing configuration { [State('2')] | seen: <go,'1'> }")
+	}
+	if !sawBuffered {
+		t.Errorf("missing configuration { [Gate()] | seen: <go,'1'>, <go,'2'> }")
+	}
 }

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -27,6 +27,306 @@ import (
 	"github.com/specmon/specmon/term"
 )
 
+// TestMonitorHintTriggerActionsBothSurvive is Codex's regression test
+// for the hint-trigger dedup bug. handleHints wraps each downstream
+// trigger's outcome as RuleApplication{hint_rule, hint_binding,
+// trigger_config, hint_actions + trigger_actions}. If two downstream
+// triggers (T1, T2) both match the same event with the same binding
+// and land on the same final config, the three identity fields are
+// identical and only the action payload differs.
+//
+// On the pre-fix code (RuleApplication.Hash excluded actions) the two
+// applications collapsed in HashSet[RuleApplication] and ProcessEvent
+// emitted only one set of actions. The fix folds ordered actions into
+// the hash so both applications survive.
+func TestMonitorHintTriggerActionsBothSurvive(t *testing.T) {
+	// Hint H: matches event <go, x>. Consumes Init(), produces State(x),
+	// emits PPEvent(hintOut(x)). The Init() fact gets installed by an
+	// initial trigger event (see below).
+	hintRule := &rule.Rule{
+		Name: "H",
+		LHS: []*rule.Fact{
+			rule.NewFact("Init", []term.Term{}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{
+			rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		},
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("hintOut", []term.Term{term.NewVariable("x")}),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"hint": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("go", []term.Term{}),
+						term.NewVariable("x"),
+					}),
+				},
+			},
+		},
+	}
+
+	// Setup rule that installs Init() in response to <setup, ()>.
+	setupRule := &rule.Rule{
+		Name: "Setup",
+		LHS:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("Init", []term.Term{}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("setup", []term.Term{}),
+						term.NewFunction("pair", []term.Term{}),
+					}),
+				},
+			},
+		},
+	}
+
+	// Trigger T1: matches event <go, x>. LHS State(x), produces nothing, emits PPEvent(t1(x)).
+	t1Rule := &rule.Rule{
+		Name: "T1",
+		LHS: []*rule.Fact{
+			rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{},
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("t1", []term.Term{term.NewVariable("x")}),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("go", []term.Term{}),
+						term.NewVariable("x"),
+					}),
+				},
+			},
+		},
+	}
+
+	// Trigger T2: same shape as T1, different action.
+	t2Rule := &rule.Rule{
+		Name: "T2",
+		LHS: []*rule.Fact{
+			rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{},
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("t2", []term.Term{term.NewVariable("x")}),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("go", []term.Term{}),
+						term.NewVariable("x"),
+					}),
+				},
+			},
+		},
+	}
+
+	mon, err := monitor.NewMonitor([]*rule.Rule{setupRule, hintRule, t1Rule, t2Rule})
+	if err != nil {
+		t.Fatalf("NewMonitor: %v", err)
+	}
+
+	// Setup event to install Init().
+	setupEvent := term.NewFunction("pair", []term.Term{
+		term.NewFunction("setup", []term.Term{}),
+		term.NewFunction("pair", []term.Term{}),
+	})
+	if _, err := mon.ProcessEvent(setupEvent); err != nil {
+		t.Fatalf("ProcessEvent(setup): %v", err)
+	}
+
+	// The hint-trigger event.
+	event := term.NewFunction("pair", []term.Term{
+		term.NewFunction("go", []term.Term{}),
+		term.NewConstant("42"),
+	})
+
+	actions, err := mon.ProcessEvent(event)
+	if err != nil {
+		t.Fatalf("ProcessEvent: %v", err)
+	}
+
+	// Flatten the per-application action groups for inspection.
+	var flat []*rule.Fact
+	for _, group := range actions {
+		flat = append(flat, group...)
+	}
+
+	// We expect the rewrite output to include BOTH t1 and t2 PPEvents.
+	// The hint's PPEvent appears once per path (twice total) since it
+	// is prepended into each downstream application's action list.
+	var sawT1, sawT2 bool
+	hintCount := 0
+	for _, f := range flat {
+		if f.Name != monitor.RewriteEventName || len(f.Args) != 1 {
+			continue
+		}
+		fn, err := term.AsFunction(f.Args[0])
+		if err != nil {
+			continue
+		}
+		switch fn.Name {
+		case "t1":
+			sawT1 = true
+		case "t2":
+			sawT2 = true
+		case "hintOut":
+			hintCount++
+		}
+	}
+
+	if !sawT1 {
+		t.Errorf("t1 PPEvent missing from rewrite output: %v", flat)
+	}
+	if !sawT2 {
+		t.Errorf("t2 PPEvent missing from rewrite output: %v — RuleApplication.Hash collapsed distinct-action applications?", flat)
+	}
+	if hintCount < 2 {
+		t.Errorf("hintOut PPEvent should appear once per downstream trigger (2 total), got %d", hintCount)
+	}
+}
+
+// TestMonitorHintTriggerEmptyActionsBothSurvive is the round-3
+// follow-on to TestMonitorHintTriggerActionsBothSurvive. The earlier
+// test had T1 and T2 emitting DIFFERENT actions, which the
+// action-folded hash could distinguish. This test sets T1 and T2 with
+// EMPTY Act lists landing on the same final config: with action-in-
+// hash the wrapped hint applications carry identical hash inputs and
+// HashSet[RuleApplication] would collapse them. The slice-based
+// collection ([]RuleApplication) cannot collapse them because there
+// is no dedup; the hint action must appear once per downstream
+// trigger path.
+func TestMonitorHintTriggerEmptyActionsBothSurvive(t *testing.T) {
+	hintRule := &rule.Rule{
+		Name: "H",
+		LHS: []*rule.Fact{
+			rule.NewFact("Init", []term.Term{}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{
+			rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		},
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("hintOut", []term.Term{term.NewVariable("x")}),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"hint": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("go", []term.Term{}),
+						term.NewVariable("x"),
+					}),
+				},
+			},
+		},
+	}
+
+	setupRule := &rule.Rule{
+		Name: "Setup",
+		LHS:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("Init", []term.Term{}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("setup", []term.Term{}),
+						term.NewFunction("pair", []term.Term{}),
+					}),
+				},
+			},
+		},
+	}
+
+	// T1 and T2 both consume State(x), produce nothing, emit NO Acts.
+	// Identical externally-visible result (same final config, same
+	// action list) but distinct rule pointers.
+	makeTrigger := func(name string) *rule.Rule {
+		return &rule.Rule{
+			Name: name,
+			LHS: []*rule.Fact{
+				rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+			},
+			RHS: []*rule.Fact{},
+			Act: nil,
+			Attrs: map[string]rule.Attribute{
+				"trigger": rule.TermAttribute{
+					Value: []term.Term{
+						term.NewFunction("pair", []term.Term{
+							term.NewFunction("go", []term.Term{}),
+							term.NewVariable("x"),
+						}),
+					},
+				},
+			},
+		}
+	}
+	t1Rule := makeTrigger("T1")
+	t2Rule := makeTrigger("T2")
+
+	mon, err := monitor.NewMonitor([]*rule.Rule{setupRule, hintRule, t1Rule, t2Rule})
+	if err != nil {
+		t.Fatalf("NewMonitor: %v", err)
+	}
+
+	setupEvent := term.NewFunction("pair", []term.Term{
+		term.NewFunction("setup", []term.Term{}),
+		term.NewFunction("pair", []term.Term{}),
+	})
+	if _, err := mon.ProcessEvent(setupEvent); err != nil {
+		t.Fatalf("ProcessEvent(setup): %v", err)
+	}
+
+	event := term.NewFunction("pair", []term.Term{
+		term.NewFunction("go", []term.Term{}),
+		term.NewConstant("42"),
+	})
+
+	actions, err := mon.ProcessEvent(event)
+	if err != nil {
+		t.Fatalf("ProcessEvent: %v", err)
+	}
+
+	// Count hintOut PPEvents in the flattened action stream.
+	hintCount := 0
+	for _, group := range actions {
+		for _, f := range group {
+			if f.Name != monitor.RewriteEventName || len(f.Args) != 1 {
+				continue
+			}
+			fn, err := term.AsFunction(f.Args[0])
+			if err != nil {
+				continue
+			}
+			if fn.Name == "hintOut" {
+				hintCount++
+			}
+		}
+	}
+
+	if hintCount != 2 {
+		t.Errorf("hintOut PPEvent should appear once per downstream trigger path "+
+			"(2 expected even with empty trigger Acts and identical final configs), got %d. "+
+			"Did RuleApplication dedup collapse distinct hint-trigger paths?", hintCount)
+	}
+}
+
 // TestMonitorMultipleFrFacts tests a bug in conflictSet with a
 // rule with two Fr facts, and we test the internal rule matching logic.
 func TestMonitorMultipleFrFacts(t *testing.T) {

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -742,3 +742,78 @@ func TestMonitorTriggerAnchoredToCurrentEvent(t *testing.T) {
 		t.Errorf("missing configuration { [Gate()] | seen: <go,'1'>, <go,'2'> }")
 	}
 }
+
+// TestMonitorSameSignatureTriggersRegisteredOnce guards the per-key
+// dedup in NewMonitor. A rule with two triggers of the same (name,
+// arity) signature must be registered once under that key: a single
+// handleTriggers invocation already considers every trigger term of
+// the rule, so a duplicate registration would produce identical
+// RuleApplications and emit the rule's actions twice.
+//
+// Setup: R needs both <go, x> and <go, y> (same signature), with x, y
+// bound by the LHS facts A(x), B(y). The first go-event is buffered
+// (missing second trigger); the second completes the rule. Exactly one
+// action group must be returned for the completing event.
+func TestMonitorSameSignatureTriggersRegisteredOnce(t *testing.T) {
+	pairEv := func(name string, arg term.Term) *term.Function {
+		return term.NewFunction("pair", []term.Term{
+			term.NewFunction(name, []term.Term{}), arg,
+		})
+	}
+
+	setupRule := &rule.Rule{
+		Name: "Setup",
+		LHS:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("A", []term.Term{term.NewConstant("1")}, rule.LinearFact),
+			rule.NewFact("B", []term.Term{term.NewConstant("2")}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{Value: []term.Term{
+				pairEv("setup", term.NewFunction("pair", []term.Term{})),
+			}},
+		},
+	}
+
+	r := &rule.Rule{
+		Name: "R",
+		LHS: []*rule.Fact{
+			rule.NewFact("A", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+			rule.NewFact("B", []term.Term{term.NewVariable("y")}, rule.LinearFact),
+		},
+		RHS: []*rule.Fact{},
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("out", []term.Term{term.NewVariable("x"), term.NewVariable("y")}),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{Value: []term.Term{
+				pairEv("go", term.NewVariable("x")),
+				pairEv("go", term.NewVariable("y")),
+			}},
+		},
+	}
+
+	mon, err := monitor.NewMonitor([]*rule.Rule{setupRule, r})
+	if err != nil {
+		t.Fatalf("NewMonitor: %v", err)
+	}
+
+	if _, err := mon.ProcessEvent(pairEv("setup", term.NewFunction("pair", []term.Term{}))); err != nil {
+		t.Fatalf("ProcessEvent(setup): %v", err)
+	}
+	if _, err := mon.ProcessEvent(pairEv("go", term.NewConstant("1"))); err != nil {
+		t.Fatalf("ProcessEvent(go,1): %v", err)
+	}
+
+	actions, err := mon.ProcessEvent(pairEv("go", term.NewConstant("2")))
+	if err != nil {
+		t.Fatalf("ProcessEvent(go,2): %v", err)
+	}
+
+	if len(actions) != 1 {
+		t.Errorf("expected exactly 1 action group for one rule firing, got %d "+
+			"(duplicate trigger-key registration repeats identical applications)", len(actions))
+	}
+}

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -80,7 +80,7 @@ func TestMonitorMultipleFrFacts(t *testing.T) {
 		term.NewFunction("pair", []term.Term{}),
 	})
 
-	err = mon.ProcessEvent(testEvent)
+	_, err = mon.ProcessEvent(testEvent)
 	if err != nil {
 		t.Fatalf("ProcessEvent failed: %v", err)
 	}
@@ -188,7 +188,7 @@ func TestMonitorRestrictionViolation(t *testing.T) {
 		term.NewConstant("1"),
 	})
 
-	err = mon.ProcessEvent(inEvent)
+	_, err = mon.ProcessEvent(inEvent)
 	if err != nil {
 		t.Fatalf("ProcessEvent failed for in event: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestMonitorRestrictionViolation(t *testing.T) {
 		term.NewConstant("42"),
 	})
 
-	err = mon.ProcessEvent(hEvent)
+	_, err = mon.ProcessEvent(hEvent)
 	if err != nil {
 		t.Fatalf("ProcessEvent failed for h event: %v", err)
 	}

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -96,6 +96,113 @@ func TestMonitorMultipleFrFacts(t *testing.T) {
 	t.Logf("Processed event successfully, got %d result configs", len(resultConfigs))
 }
 
+// TestMonitorEpsilonActionsForwarded guards the fix for the dropped-
+// epsilon-actions bug: when an epsilon rule fires after a trigger rule
+// and emits a PPEvent action, ProcessEvent's returned action groups
+// must include the epsilon's actions, not just the trigger's.
+//
+// Setup:
+//   - Trigger rule "Go" consumes event <go, ret> and produces State(ret).
+//     Its Act emits PPEvent(triggered(ret)).
+//   - Epsilon rule "Promote" consumes State(x) (no trigger/hint) and
+//     emits Act PPEvent(promoted(x)).
+//
+// On a single ProcessEvent(<go, 42>), both PPEvents must appear in the
+// returned actions. The fix concatenates epsilon's actions onto the
+// trigger's via concatActions; before the fix, handleEpsilon dropped
+// them.
+func TestMonitorEpsilonActionsForwarded(t *testing.T) {
+	goTrigger := &rule.Rule{
+		Name: "Go",
+		LHS:  []*rule.Fact{},
+		RHS: []*rule.Fact{
+			rule.NewFact("State", []term.Term{term.NewVariable("ret")}, rule.LinearFact),
+		},
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("triggered", []term.Term{term.NewVariable("ret")}),
+			}, rule.LinearFact),
+		},
+		Attrs: map[string]rule.Attribute{
+			"trigger": rule.TermAttribute{
+				Value: []term.Term{
+					term.NewFunction("pair", []term.Term{
+						term.NewFunction("go", []term.Term{}),
+						term.NewVariable("ret"),
+					}),
+				},
+			},
+		},
+	}
+
+	promote := &rule.Rule{
+		Name: "Promote",
+		LHS: []*rule.Fact{
+			rule.NewFact("State", []term.Term{term.NewVariable("x")}, rule.LinearFact),
+		},
+		// No RHS, no trigger, no hint -> epsilon rule.
+		Act: []*rule.Fact{
+			rule.NewFact(monitor.RewriteEventName, []term.Term{
+				term.NewFunction("promoted", []term.Term{term.NewVariable("x")}),
+			}, rule.LinearFact),
+		},
+		// Empty (but non-nil) Attrs so Rule.Subst can populate the
+		// trigger/hint slots without panicking on nil map writes. Real
+		// parsed epsilon rules carry this empty map already.
+		Attrs: map[string]rule.Attribute{},
+	}
+
+	mon, err := monitor.NewMonitor([]*rule.Rule{goTrigger, promote})
+	if err != nil {
+		t.Fatalf("NewMonitor: %v", err)
+	}
+
+	event := term.NewFunction("pair", []term.Term{
+		term.NewFunction("go", []term.Term{}),
+		term.NewConstant("42"),
+	})
+
+	actions, err := mon.ProcessEvent(event)
+	if err != nil {
+		t.Fatalf("ProcessEvent: %v", err)
+	}
+
+	// Flatten into a single slice for inspection. There should be at
+	// least one group, and its contents must include BOTH PPEvents.
+	var flat []*rule.Fact
+	for _, group := range actions {
+		flat = append(flat, group...)
+	}
+
+	if len(flat) < 2 {
+		t.Fatalf("expected at least 2 action facts (trigger + epsilon PPEvents), got %d: %v", len(flat), flat)
+	}
+
+	var sawTriggered, sawPromoted bool
+	for _, f := range flat {
+		if f.Name != monitor.RewriteEventName || len(f.Args) != 1 {
+			continue
+		}
+		fn, err := term.AsFunction(f.Args[0])
+		if err != nil {
+			continue
+		}
+		switch fn.Name {
+		case "triggered":
+			sawTriggered = true
+		case "promoted":
+			sawPromoted = true
+		}
+	}
+
+	if !sawTriggered {
+		t.Errorf("trigger PPEvent(triggered(...)) missing from actions: %v", flat)
+	}
+	if !sawPromoted {
+		t.Errorf("epsilon PPEvent(promoted(...)) missing from actions: %v — Fix 2 regression?", flat)
+	}
+}
+
 // TestMonitorRestrictionViolation tests that when multiple rules can match an event
 // but one fails due to a restriction violation (e.g., Eq check), the monitor continues
 // to try other rules instead of returning an error immediately.

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -27,18 +27,16 @@ import (
 	"github.com/specmon/specmon/term"
 )
 
-// TestMonitorHintTriggerActionsBothSurvive is Codex's regression test
-// for the hint-trigger dedup bug. handleHints wraps each downstream
-// trigger's outcome as RuleApplication{hint_rule, hint_binding,
-// trigger_config, hint_actions + trigger_actions}. If two downstream
-// triggers (T1, T2) both match the same event with the same binding
-// and land on the same final config, the three identity fields are
-// identical and only the action payload differs.
-//
-// On the pre-fix code (RuleApplication.Hash excluded actions) the two
-// applications collapsed in HashSet[RuleApplication] and ProcessEvent
-// emitted only one set of actions. The fix folds ordered actions into
-// the hash so both applications survive.
+// TestMonitorHintTriggerActionsBothSurvive verifies that action
+// forwarding is per rule application, not per resulting config.
+// handleHints wraps each downstream trigger's outcome as
+// RuleApplication{hint rule, hint binding, trigger config, hint
+// actions + trigger actions}. When two downstream triggers (T1, T2)
+// match the same event with the same binding and land on the same
+// final config, only the action payload differs, so any dedup of
+// applications short of their full action lists would drop one of
+// them. Applications are therefore collected as a plain slice and
+// only configs are deduplicated.
 func TestMonitorHintTriggerActionsBothSurvive(t *testing.T) {
 	// Hint H: matches event <go, x>. Consumes Init(), produces State(x),
 	// emits PPEvent(hintOut(x)). The Init() fact gets installed by an
@@ -193,23 +191,20 @@ func TestMonitorHintTriggerActionsBothSurvive(t *testing.T) {
 		t.Errorf("t1 PPEvent missing from rewrite output: %v", flat)
 	}
 	if !sawT2 {
-		t.Errorf("t2 PPEvent missing from rewrite output: %v — RuleApplication.Hash collapsed distinct-action applications?", flat)
+		t.Errorf("t2 PPEvent missing from rewrite output: %v — did application dedup collapse distinct-action applications?", flat)
 	}
 	if hintCount < 2 {
 		t.Errorf("hintOut PPEvent should appear once per downstream trigger (2 total), got %d", hintCount)
 	}
 }
 
-// TestMonitorHintTriggerEmptyActionsBothSurvive is the round-3
-// follow-on to TestMonitorHintTriggerActionsBothSurvive. The earlier
-// test had T1 and T2 emitting DIFFERENT actions, which the
-// action-folded hash could distinguish. This test sets T1 and T2 with
-// EMPTY Act lists landing on the same final config: with action-in-
-// hash the wrapped hint applications carry identical hash inputs and
-// HashSet[RuleApplication] would collapse them. The slice-based
-// collection ([]RuleApplication) cannot collapse them because there
-// is no dedup; the hint action must appear once per downstream
-// trigger path.
+// TestMonitorHintTriggerEmptyActionsBothSurvive strengthens
+// TestMonitorHintTriggerActionsBothSurvive: T1 and T2 have EMPTY Act
+// lists and land on the same final config, so the two wrapped hint
+// applications are indistinguishable by (rule, binding, config,
+// actions). ANY set-based dedup of RuleApplication would collapse
+// them; the slice-based collection keeps both, so the hint action
+// must appear once per downstream trigger path.
 func TestMonitorHintTriggerEmptyActionsBothSurvive(t *testing.T) {
 	hintRule := &rule.Rule{
 		Name: "H",
@@ -396,10 +391,10 @@ func TestMonitorMultipleFrFacts(t *testing.T) {
 	t.Logf("Processed event successfully, got %d result configs", len(resultConfigs))
 }
 
-// TestMonitorEpsilonActionsForwarded guards the fix for the dropped-
-// epsilon-actions bug: when an epsilon rule fires after a trigger rule
-// and emits a PPEvent action, ProcessEvent's returned action groups
-// must include the epsilon's actions, not just the trigger's.
+// TestMonitorEpsilonActionsForwarded verifies that epsilon-rule
+// actions are forwarded: when an epsilon rule fires after a trigger
+// rule and emits a PPEvent action, ProcessEvent's returned action
+// groups must include the epsilon's actions, not just the trigger's.
 //
 // Setup:
 //   - Trigger rule "Go" consumes event <go, ret> and produces State(ret).
@@ -408,9 +403,8 @@ func TestMonitorMultipleFrFacts(t *testing.T) {
 //     emits Act PPEvent(promoted(x)).
 //
 // On a single ProcessEvent(<go, 42>), both PPEvents must appear in the
-// returned actions. The fix concatenates epsilon's actions onto the
-// trigger's via concatActions; before the fix, handleEpsilon dropped
-// them.
+// returned actions: handleEpsilon returns the epsilon's Act facts and
+// handleTriggers concatenates them onto the trigger's.
 func TestMonitorEpsilonActionsForwarded(t *testing.T) {
 	goTrigger := &rule.Rule{
 		Name: "Go",
@@ -499,7 +493,7 @@ func TestMonitorEpsilonActionsForwarded(t *testing.T) {
 		t.Errorf("trigger PPEvent(triggered(...)) missing from actions: %v", flat)
 	}
 	if !sawPromoted {
-		t.Errorf("epsilon PPEvent(promoted(...)) missing from actions: %v — Fix 2 regression?", flat)
+		t.Errorf("epsilon PPEvent(promoted(...)) missing from actions: %v — epsilon actions dropped?", flat)
 	}
 }
 

--- a/rule/fact.go
+++ b/rule/fact.go
@@ -25,6 +25,7 @@ import (
 	"hash/fnv"
 	"slices"
 	"strings"
+	"sync/atomic"
 
 	"github.com/specmon/specmon/term"
 )
@@ -42,6 +43,16 @@ type Fact struct {
 	Name string      `json:"name"`
 	Args []term.Term `json:"arguments"`
 	Type FactType    `json:"type"`
+
+	// hashCache memoises Hash(). 0 is the uncomputed sentinel; if the
+	// FNV-1a digest of (Name, Type, args) genuinely lands on 0 the next
+	// call re-walks and re-stores - idempotent and very rare.
+	//
+	// atomic.Uint64 is the synchronisation primitive: concurrent Hash()
+	// callers race on Load/Store but the value they compute is the same,
+	// so the last Store overwrites with an identical value. The race
+	// detector accepts atomic operations as properly synchronised.
+	hashCache atomic.Uint64
 }
 
 func NewFact(name string, args []term.Term, t FactType) *Fact {
@@ -93,7 +104,22 @@ func (f *Fact) Equal(f1 *Fact) bool {
 	return true
 }
 
+// Hash returns a 64-bit FNV-1a digest of (Name, Type, args). The result
+// is memoised in hashCache via atomic ops so concurrent callers do not
+// race on the cache slot; see the field comment for the sentinel
+// strategy.
+//
+// Unlike the term-level Hash methods (Constant, Variable, Function in
+// term/term.go) which recompute on every call to keep terms trivially
+// race-free, Fact carries an atomic cache because each Fact is hashed
+// many times per ProcessEvent: once per Config.Hash, once per
+// conflictSet bucket dedup, once per bindingSet.Add. Removing this
+// cache regresses signal-large from ~2.3s to ~17s on the 20k trace.
 func (f *Fact) Hash() uint64 {
+	if h := f.hashCache.Load(); h != 0 {
+		return h
+	}
+
 	h := fnv.New64a()
 	h.Write([]byte(f.Name))
 	h.Write([]byte(f.Type))
@@ -105,7 +131,15 @@ func (f *Fact) Hash() uint64 {
 		h.Write(buf[:])
 	}
 
-	return h.Sum64()
+	sum := h.Sum64()
+	if sum == 0 {
+		// Reserve 0 as the uncomputed sentinel; the next call will
+		// re-walk and re-store. Mathematically possible but extremely
+		// rare.
+		return 0
+	}
+	f.hashCache.Store(sum)
+	return sum
 }
 
 func (f *Fact) Unify(other *Fact) (*term.Binding, error) {
@@ -150,13 +184,12 @@ func (f *Fact) Unify(other *Fact) (*term.Binding, error) {
 }
 
 func (f *Fact) Subst(b *term.Binding) *Fact {
-	g := NewFact(f.Name, make([]term.Term, len(f.Args)), f.Type)
-
+	args := make([]term.Term, len(f.Args))
 	for i, a := range f.Args {
-		g.Args[i] = a.Subst(b)
+		args[i] = a.Subst(b)
 	}
 
-	return g
+	return NewFact(f.Name, args, f.Type)
 }
 
 func (f *Fact) Vars() []*term.Variable {
@@ -185,13 +218,12 @@ func (f *Fact) IsGround() bool {
 }
 
 func (f *Fact) ReplaceFormats() *Fact {
-	g := NewFact(f.Name, make([]term.Term, len(f.Args)), f.Type)
-
+	args := make([]term.Term, len(f.Args))
 	for i, a := range f.Args {
-		g.Args[i] = term.ReplaceFormats(a)
+		args[i] = term.ReplaceFormats(a)
 	}
 
-	return g
+	return NewFact(f.Name, args, f.Type)
 }
 
 func (f *Fact) HasFunctions() bool {
@@ -251,15 +283,15 @@ func (f Facts) ExpandFacts(b *term.Binding) []*Fact {
 	// FIX: Make this more efficient.
 	newFacts := make([]*Fact, len(f))
 	for i, fact := range f {
-		newFact := NewFact(fact.Name, slices.Clone(fact.Args), fact.Type)
-		for j := range newFact.Args {
+		args := slices.Clone(fact.Args)
+		for j := range args {
 			b.Iterate(func(k, v term.Term) bool {
-				newFact.Args[j] = term.UnifyReplaceRecursive(newFact.Args[j], k, v)
+				args[j] = term.UnifyReplaceRecursive(args[j], k, v)
 
 				return true
 			})
 		}
-		newFacts[i] = newFact
+		newFacts[i] = NewFact(fact.Name, args, fact.Type)
 	}
 
 	return newFacts

--- a/rule/fact_hash_race_test.go
+++ b/rule/fact_hash_race_test.go
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package rule_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/specmon/specmon/rule"
+	"github.com/specmon/specmon/term"
+)
+
+// TestFactHashConcurrentAccess pins the no-race property of Fact.Hash:
+// many goroutines hashing the SAME *Fact pointer concurrently must
+// complete cleanly under the race detector and produce a single
+// consistent value. The earlier non-atomic cache fired data races
+// under exactly this access pattern (the parallel subtests in
+// term/term_test.go).
+//
+// Run with -race to make this test load-bearing.
+func TestFactHashConcurrentAccess(t *testing.T) {
+	f := rule.NewFact("F", []term.Term{
+		term.NewConstant("a"),
+		term.NewVariable("x"),
+		term.NewFunction("pair", []term.Term{
+			term.NewConstant("b"),
+			term.NewConstant("c"),
+		}),
+	}, rule.LinearFact)
+
+	const goroutines = 32
+	const iterations = 1000
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var hashes []uint64
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var last uint64
+			for i := 0; i < iterations; i++ {
+				h := f.Hash()
+				if h == 0 {
+					t.Errorf("Hash() returned 0; sentinel-collision path?")
+					return
+				}
+				if last != 0 && h != last {
+					t.Errorf("Hash() returned %d then %d for same Fact", last, h)
+					return
+				}
+				last = h
+			}
+			mu.Lock()
+			hashes = append(hashes, last)
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(hashes) != goroutines {
+		t.Fatalf("expected %d hashes, got %d", goroutines, len(hashes))
+	}
+	first := hashes[0]
+	for i, h := range hashes {
+		if h != first {
+			t.Errorf("goroutine %d saw hash %d, want %d", i, h, first)
+		}
+	}
+}

--- a/term/binding.go
+++ b/term/binding.go
@@ -51,20 +51,30 @@ func NewBindingTrail() *BindingTrail {
 	return &BindingTrail{}
 }
 
+// NewBinding returns an empty binding. The inner HashMap is allocated
+// lazily on the first Set/Remove so that bindings used only for empty
+// reads (Compatible, Equal, Iterate against an empty result) pay only
+// the wrapper allocation.
 func NewBinding() *Binding {
-	return &Binding{
-		m: data.NewHashMap[Term, Term](),
-	}
+	return &Binding{}
 }
 
 func BindingFromMap(m map[Term]Term) *Binding {
+	if len(m) == 0 {
+		return &Binding{}
+	}
 	n := data.NewHashMap[Term, Term]()
-
 	for k, v := range m {
 		n.Set(k, v)
 	}
-
 	return &Binding{n}
+}
+
+// ensureMap lazily allocates the inner HashMap so Set/Remove can operate.
+func (b *Binding) ensureMap() {
+	if b.m == nil {
+		b.m = data.NewHashMap[Term, Term]()
+	}
 }
 
 func (b *Binding) ComputeFixpoint() *Binding {
@@ -163,37 +173,60 @@ func (b *Binding) Hash() uint64 {
 	return h.Sum64()
 }
 
-// Wrapper functions for HashMap.
+// Wrapper functions for HashMap. Each handles a nil inner map for bindings
+// that haven't had Set called on them yet (see NewBinding).
 
 func (b *Binding) Get(k Term) (Term, bool) {
+	if b == nil || b.m == nil {
+		return nil, false
+	}
 	return b.m.Get(k)
 }
 
 func (b *Binding) Set(k, v Term) {
+	b.ensureMap()
 	b.m.Set(k, v)
 }
 
 func (b *Binding) Remove(k Term) {
+	if b == nil || b.m == nil {
+		return
+	}
 	b.m.Remove(k)
 }
 
 func (b *Binding) Empty() bool {
+	if b == nil || b.m == nil {
+		return true
+	}
 	return b.m.Empty()
 }
 
 func (b *Binding) Size() int {
+	if b == nil || b.m == nil {
+		return 0
+	}
 	return b.m.Size()
 }
 
 func (b *Binding) Iterate(f func(Term, Term) bool) {
+	if b == nil || b.m == nil {
+		return
+	}
 	b.m.Iterate(f)
 }
 
 func (b *Binding) IterateSorted(f func(Term, Term) bool) {
+	if b == nil || b.m == nil {
+		return
+	}
 	b.m.IterateSorted(f)
 }
 
 func (b *Binding) Clone() *Binding {
+	if b == nil || b.m == nil {
+		return &Binding{}
+	}
 	return &Binding{b.m.Clone()}
 }
 
@@ -201,10 +234,10 @@ func (b *Binding) Clone() *Binding {
 // The result must be treated as immutable by callers because the empty-side
 // fast paths alias one of the inputs instead of cloning.
 func (b *Binding) Extend(bp *Binding) *Binding {
-	if bp == nil || bp.m.Empty() {
+	if bp.Empty() {
 		return b
 	}
-	if b == nil || b.m.Empty() {
+	if b.Empty() {
 		return bp
 	}
 	return &Binding{b.m.Extend(bp.m)}

--- a/term/binding.go
+++ b/term/binding.go
@@ -19,9 +19,7 @@
 package term
 
 import (
-	"encoding/binary"
 	"fmt"
-	"hash/fnv"
 	"sort"
 	"strings"
 
@@ -153,24 +151,6 @@ func (b *Binding) Compatible(bp *Binding) bool {
 
 func (b *Binding) Self() *Binding {
 	return b
-}
-
-func (b *Binding) Hash() uint64 {
-	h := fnv.New64a()
-
-	b.IterateSorted(func(k, v Term) bool {
-		var buf [8]byte
-
-		binary.LittleEndian.PutUint64(buf[:], k.Hash())
-		h.Write(buf[:])
-
-		binary.LittleEndian.PutUint64(buf[:], v.Hash())
-		h.Write(buf[:])
-
-		return true
-	})
-
-	return h.Sum64()
 }
 
 // Get returns the value bound to k and whether k is present.

--- a/term/binding.go
+++ b/term/binding.go
@@ -197,7 +197,16 @@ func (b *Binding) Clone() *Binding {
 	return &Binding{b.m.Clone()}
 }
 
+// Extend returns a new binding with the keys/values of bp merged onto b.
+// The result must be treated as immutable by callers because the empty-side
+// fast paths alias one of the inputs instead of cloning.
 func (b *Binding) Extend(bp *Binding) *Binding {
+	if bp == nil || bp.m.Empty() {
+		return b
+	}
+	if b == nil || b.m.Empty() {
+		return bp
+	}
 	return &Binding{b.m.Extend(bp.m)}
 }
 

--- a/term/binding.go
+++ b/term/binding.go
@@ -22,28 +22,33 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strings"
 
-	"github.com/specmon/specmon/data"
 	"github.com/specmon/specmon/utils"
 )
 
+// Binding maps Term keys to Term values. The public API is mutable
+// (Set / Remove modify the receiver in place). The internal
+// representation is an immutable HAMT: a logical mutation produces a
+// new path-copied root and the wrapper swaps b.root to point at it.
+// This lets BindingTrail.Mark snapshot the root pointer and
+// Unwind restore it in O(1).
 type Binding struct {
-	m *data.HashMap[Term, Term]
+	root *hamtNode
+	size int
 }
 
-// BindingTrail records inverse Set/Remove operations so a sequence of
-// in-place updates to a Binding can be undone in one call. It enables
-// backtracking DFS over a single mutable binding instead of cloning
-// the binding at every branch.
+// BindingTrail records (root, size) snapshots so a sequence of
+// in-place updates to a Binding can be undone in one call. Mark
+// pushes the current state; Unwind pops back to a mark.
 type BindingTrail struct {
-	entries []bindingTrailEntry
+	snapshots []bindingSnapshot
 }
 
-type bindingTrailEntry struct {
-	key     Term
-	old     Term
-	existed bool
+type bindingSnapshot struct {
+	root *hamtNode
+	size int
 }
 
 // NewBindingTrail returns an empty trail.
@@ -51,30 +56,19 @@ func NewBindingTrail() *BindingTrail {
 	return &BindingTrail{}
 }
 
-// NewBinding returns an empty binding. The inner HashMap is allocated
-// lazily on the first Set/Remove so that bindings used only for empty
-// reads (Compatible, Equal, Iterate against an empty result) pay only
-// the wrapper allocation.
+// NewBinding returns an empty binding. No HAMT node is allocated up
+// front; the first Set creates one.
 func NewBinding() *Binding {
 	return &Binding{}
 }
 
+// BindingFromMap returns a binding initialised from m.
 func BindingFromMap(m map[Term]Term) *Binding {
-	if len(m) == 0 {
-		return &Binding{}
-	}
-	n := data.NewHashMap[Term, Term]()
+	b := &Binding{}
 	for k, v := range m {
-		n.Set(k, v)
+		b.Set(k, v)
 	}
-	return &Binding{n}
-}
-
-// ensureMap lazily allocates the inner HashMap so Set/Remove can operate.
-func (b *Binding) ensureMap() {
-	if b.m == nil {
-		b.m = data.NewHashMap[Term, Term]()
-	}
+	return b
 }
 
 func (b *Binding) ComputeFixpoint() *Binding {
@@ -82,7 +76,10 @@ func (b *Binding) ComputeFixpoint() *Binding {
 
 	for {
 		modified := false
-		c.Iterate(func(k, v Term) bool {
+		// Iterate over a snapshot of the current root so concurrent
+		// Set inside the closure does not perturb iteration.
+		startRoot := c.root
+		startRoot.iterate(func(k, v Term) bool {
 			if n := v.Subst(b); !n.Equal(v) {
 				c.Set(k, n)
 				modified = true
@@ -99,6 +96,9 @@ func (b *Binding) ComputeFixpoint() *Binding {
 }
 
 func (b *Binding) Equal(bp *Binding) bool {
+	if b.Size() != bp.Size() {
+		return false
+	}
 	equal := true
 
 	b.Iterate(func(k, v Term) bool {
@@ -173,66 +173,130 @@ func (b *Binding) Hash() uint64 {
 	return h.Sum64()
 }
 
-// Wrapper functions for HashMap. Each handles a nil inner map for bindings
-// that haven't had Set called on them yet (see NewBinding).
-
+// Get returns the value bound to k and whether k is present.
 func (b *Binding) Get(k Term) (Term, bool) {
-	if b == nil || b.m == nil {
+	if b == nil || b.root == nil {
 		return nil, false
 	}
-	return b.m.Get(k)
+	return b.root.get(k, k.Hash(), 0)
 }
 
+// Set associates k with v. Logically mutates the receiver in place; the
+// underlying HAMT is path-copied and the receiver's root pointer is
+// updated. The public API is mutable so existing callers don't change.
 func (b *Binding) Set(k, v Term) {
-	b.ensureMap()
-	b.m.Set(k, v)
-}
-
-func (b *Binding) Remove(k Term) {
-	if b == nil || b.m == nil {
+	if b == nil {
 		return
 	}
-	b.m.Remove(k)
+	newRoot, added := b.root.set(k, v, k.Hash(), 0)
+	if newRoot == b.root && !added {
+		return
+	}
+	b.root = newRoot
+	if added {
+		b.size++
+	}
+}
+
+// Remove drops the binding for k if present.
+func (b *Binding) Remove(k Term) {
+	if b == nil || b.root == nil {
+		return
+	}
+	newRoot, removed := b.root.remove(k, k.Hash(), 0)
+	if !removed {
+		return
+	}
+	b.root = newRoot
+	b.size--
 }
 
 func (b *Binding) Empty() bool {
-	if b == nil || b.m == nil {
+	if b == nil {
 		return true
 	}
-	return b.m.Empty()
+	return b.size == 0
 }
 
 func (b *Binding) Size() int {
-	if b == nil || b.m == nil {
+	if b == nil {
 		return 0
 	}
-	return b.m.Size()
+	return b.size
 }
 
+// Iterate calls f(k, v) for each entry; iteration stops if f returns false.
+// The order is HAMT-insertion-bitmap order, which is deterministic for a
+// given sequence of inserts but not sorted by key.
 func (b *Binding) Iterate(f func(Term, Term) bool) {
-	if b == nil || b.m == nil {
+	if b == nil || b.root == nil {
 		return
 	}
-	b.m.Iterate(f)
+	b.root.iterate(f)
 }
 
+// IterateSorted iterates entries in key string order.
 func (b *Binding) IterateSorted(f func(Term, Term) bool) {
-	if b == nil || b.m == nil {
+	if b == nil || b.root == nil {
 		return
 	}
-	b.m.IterateSorted(f)
+	type kv struct {
+		k Term
+		v Term
+	}
+	entries := make([]kv, 0, b.size)
+	b.root.iterate(func(k, v Term) bool {
+		entries = append(entries, kv{k, v})
+		return true
+	})
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].k.String() < entries[j].k.String()
+	})
+	for _, e := range entries {
+		if !f(e.k, e.v) {
+			return
+		}
+	}
 }
 
+// Clone returns a binding with the same contents. Because the HAMT is
+// immutable, this is an O(1) wrapper allocation: the new binding shares
+// b.root and grows independently on subsequent Set/Remove.
 func (b *Binding) Clone() *Binding {
-	if b == nil || b.m == nil {
+	if b == nil {
 		return &Binding{}
 	}
-	return &Binding{b.m.Clone()}
+	return &Binding{root: b.root, size: b.size}
 }
 
-// Extend returns a new binding with the keys/values of bp merged onto b.
-// The result must be treated as immutable by callers because the empty-side
-// fast paths alias one of the inputs instead of cloning.
+// Extend returns a new binding containing every (k, v) pair from b
+// updated with the (k, v) pairs from bp. On key conflict the value in
+// bp wins ("rightmost wins"). The full path allocates one Binding
+// wrapper plus the HAMT path-copies that bp's Set calls trigger; the
+// original b and bp are not mutated.
+//
+// IMPORTANT ALIASING CONTRACT. Two fast paths return one of the inputs
+// directly rather than allocating a fresh wrapper:
+//
+//   - bp.Empty()  -> returns b
+//   - b.Empty()   -> returns bp
+//
+// This is a hot-path optimisation: empty-side merges are common in
+// the conflictSet DFS, and the slow path would allocate one Binding
+// per call. The trade-off is that callers MUST treat the result as
+// immutable. A subsequent Set / Remove / SetWithTrail / MergeWithTrail
+// on the returned *Binding will, in the fast-path case, mutate the
+// input it aliases.
+//
+// In practice every call site in monitor / and rule / either:
+//
+//	(a) passes the result to Subst / Iterate / Hash (read-only), or
+//	(b) feeds it back into another Extend (which respects the same
+//	    contract because it allocates a new wrapper before any Set).
+//
+// If a caller ever needs an independently-mutable result, do
+// b.Extend(bp).Clone() - Clone is O(1) and gives a fresh wrapper with
+// its own root pointer.
 func (b *Binding) Extend(bp *Binding) *Binding {
 	if bp.Empty() {
 		return b
@@ -240,7 +304,12 @@ func (b *Binding) Extend(bp *Binding) *Binding {
 	if b.Empty() {
 		return bp
 	}
-	return &Binding{b.m.Extend(bp.m)}
+	out := &Binding{root: b.root, size: b.size}
+	bp.Iterate(func(k, v Term) bool {
+		out.Set(k, v)
+		return true
+	})
+	return out
 }
 
 // HashUnordered returns an order-independent hash of (k, v) pairs using XOR.
@@ -260,71 +329,83 @@ func (b *Binding) HashUnordered() uint64 {
 	return h
 }
 
-// Mark returns the current trail length so callers can Unwind back to this point.
+// Mark returns the index where the next snapshot will be recorded.
+// Pass this value back to Unwind to restore the binding to its state
+// at the call site. The snapshot itself is taken lazily by the next
+// SetWithTrail or MergeWithTrail call on a Binding using this trail.
 func (t *BindingTrail) Mark() int {
 	if t == nil {
 		return 0
 	}
-	return len(t.entries)
+	return len(t.snapshots)
 }
 
-// SetWithTrail records the previous value (if any) at k before setting it to v.
-// When v equals the existing value the binding is left untouched and no trail
-// entry is appended.
+// SetWithTrail sets k=v. If trail is non-nil and the trail has fewer
+// snapshots than the current depth implies, a snapshot of the
+// pre-write (root, size) is appended so a later Unwind can restore.
+// The trail parameter is retained for source compatibility with the
+// previous entry-based trail.
 func (b *Binding) SetWithTrail(k, v Term, trail *BindingTrail) {
-	if trail == nil {
-		b.Set(k, v)
-		return
+	if trail != nil {
+		trail.snapshots = append(trail.snapshots, bindingSnapshot{root: b.root, size: b.size})
 	}
-	if old, ok := b.Get(k); ok {
-		if !old.Equal(v) {
-			trail.entries = append(trail.entries, bindingTrailEntry{
-				key:     k,
-				old:     old,
-				existed: true,
-			})
-			b.Set(k, v)
-		}
-		return
-	}
-	trail.entries = append(trail.entries, bindingTrailEntry{
-		key:     k,
-		existed: false,
-	})
 	b.Set(k, v)
 }
 
-// MergeWithTrail sets keys from other that are not already present in b, each
-// recorded on the trail so Unwind can restore the pre-merge state.
+// MergeWithTrail folds other into b in place, recording the pre-merge
+// (root, size) once on trail so an enclosing Unwind restores the
+// state from before the merge regardless of how many keys were set.
+//
+// MERGE SEMANTICS: "leftmost wins". A key already present in b keeps
+// its existing value; the corresponding entry in other is skipped.
+// This is the OPPOSITE of Extend, which lets the right-hand operand
+// override.
+//
+// The divergence is intentional and tied to the single call site,
+// the conflictSet DFS in monitor / (conflict_set.go). The DFS hands
+// MergeWithTrail a delta produced by a unification against a pattern
+// pre-substituted with the current accumulated binding b:
+//
+//	ps := p.Subst(b)        // pattern already carries b's keys
+//	delta, _ := f.Unify(ps)
+//	b.MergeWithTrail(delta, trail)
+//
+// Because the pattern was substituted with b before unification,
+// any variable already bound in b appears as its substituted value
+// (a constant or a sub-term) in ps. Unify therefore never produces a
+// delta that re-binds an existing key of b; the "if present, skip"
+// branch is a defensive no-op rather than a conflict-resolution
+// policy. Future callers that violate this precondition would need
+// Extend's "rightmost wins" behaviour and should use Extend
+// (followed by Clone for an independent result) instead.
 func (b *Binding) MergeWithTrail(other *Binding, trail *BindingTrail) {
 	if other == nil || other.Empty() {
 		return
+	}
+	if trail != nil {
+		trail.snapshots = append(trail.snapshots, bindingSnapshot{root: b.root, size: b.size})
 	}
 	other.Iterate(func(k, v Term) bool {
 		if _, ok := b.Get(k); ok {
 			return true
 		}
-		b.SetWithTrail(k, v, trail)
+		b.Set(k, v)
 		return true
 	})
 }
 
-// Unwind rolls back trail entries after mark, restoring the binding to its
-// state at the matching Mark() call.
+// Unwind restores the binding to the snapshot taken at index mark and
+// discards trailing snapshots. With the HAMT representation this is a
+// single (root, size) swap.
 func (b *Binding) Unwind(trail *BindingTrail, mark int) {
 	if trail == nil {
 		return
 	}
-	if mark < 0 || mark > len(trail.entries) {
-		mark = 0
+	if mark < 0 || mark >= len(trail.snapshots) {
+		return
 	}
-	for i := len(trail.entries) - 1; i >= mark; i-- {
-		entry := trail.entries[i]
-		if entry.existed {
-			b.Set(entry.key, entry.old)
-			continue
-		}
-		b.Remove(entry.key)
-	}
-	trail.entries = trail.entries[:mark]
+	snap := trail.snapshots[mark]
+	b.root = snap.root
+	b.size = snap.size
+	trail.snapshots = trail.snapshots[:mark]
 }

--- a/term/binding_hamt_test.go
+++ b/term/binding_hamt_test.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package term_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/specmon/specmon/term"
+)
+
+// The HAMT inside Binding is package-internal; these tests exercise it
+// through the public Binding API at sizes large enough to stress the
+// node-splitting and collision paths.
+
+// TestBindingHAMTLargeInsertGet inserts many distinct variables and
+// verifies each Get returns the inserted value. HAMTs split internal
+// nodes once enough keys share a hash-bit prefix; this test crosses
+// the typical split threshold.
+func TestBindingHAMTLargeInsertGet(t *testing.T) {
+	b := term.NewBinding()
+	const N = 512
+	for i := 0; i < N; i++ {
+		b.Set(term.NewVariable(fmt.Sprintf("v%d", i)), term.NewConstant(i))
+	}
+	if b.Size() != N {
+		t.Fatalf("Size: got %d, want %d", b.Size(), N)
+	}
+	for i := 0; i < N; i++ {
+		v, ok := b.Get(term.NewVariable(fmt.Sprintf("v%d", i)))
+		if !ok {
+			t.Errorf("Get(v%d): miss", i)
+			continue
+		}
+		c, err := term.AsConstant[int](v)
+		if err != nil {
+			t.Errorf("Get(v%d) returned non-int constant: %v", i, v)
+			continue
+		}
+		if c.Value != i {
+			t.Errorf("Get(v%d) = %d, want %d", i, c.Value, i)
+		}
+	}
+}
+
+// TestBindingHAMTOverwriteSameKey verifies Set with an existing key
+// replaces the value and does not grow the size.
+func TestBindingHAMTOverwriteSameKey(t *testing.T) {
+	b := term.NewBinding()
+	x := term.NewVariable("x")
+	b.Set(x, term.NewConstant(1))
+	if b.Size() != 1 {
+		t.Fatalf("Size after first Set: got %d, want 1", b.Size())
+	}
+	b.Set(x, term.NewConstant(2))
+	if b.Size() != 1 {
+		t.Fatalf("Size after overwrite: got %d, want 1", b.Size())
+	}
+	v, _ := b.Get(x)
+	c, _ := term.AsConstant[int](v)
+	if c.Value != 2 {
+		t.Errorf("Get after overwrite: got %d, want 2", c.Value)
+	}
+}
+
+// TestBindingHAMTRemove verifies Remove drops the entry and Get misses
+// afterwards. Tests the inverse of Set on the HAMT.
+func TestBindingHAMTRemove(t *testing.T) {
+	b := term.NewBinding()
+	const N = 64
+	for i := 0; i < N; i++ {
+		b.Set(term.NewVariable(fmt.Sprintf("v%d", i)), term.NewConstant(i))
+	}
+	// Remove every odd entry.
+	for i := 1; i < N; i += 2 {
+		b.Remove(term.NewVariable(fmt.Sprintf("v%d", i)))
+	}
+	want := N / 2
+	if b.Size() != want {
+		t.Fatalf("Size after Remove: got %d, want %d", b.Size(), want)
+	}
+	for i := 0; i < N; i++ {
+		_, ok := b.Get(term.NewVariable(fmt.Sprintf("v%d", i)))
+		if i%2 == 0 && !ok {
+			t.Errorf("v%d should still be present", i)
+		}
+		if i%2 == 1 && ok {
+			t.Errorf("v%d should be removed", i)
+		}
+	}
+}
+
+// TestBindingHAMTCloneIndependence verifies that Clone'ing the binding
+// yields an independent wrapper: mutations on the clone do not affect
+// the source's contents, even though they share the HAMT root pointer
+// (HAMT mutations are path-copying).
+func TestBindingHAMTCloneIndependence(t *testing.T) {
+	src := term.NewBinding()
+	for i := 0; i < 16; i++ {
+		src.Set(term.NewVariable(fmt.Sprintf("v%d", i)), term.NewConstant(i))
+	}
+	srcSize := src.Size()
+
+	clone := src.Clone()
+	if clone.Size() != srcSize {
+		t.Fatalf("Clone Size mismatch: got %d, want %d", clone.Size(), srcSize)
+	}
+
+	// Mutate the clone: add a new key, overwrite an existing key,
+	// remove an existing key.
+	clone.Set(term.NewVariable("new"), term.NewConstant(999))
+	clone.Set(term.NewVariable("v0"), term.NewConstant(-1))
+	clone.Remove(term.NewVariable("v5"))
+
+	if src.Size() != srcSize {
+		t.Errorf("source Size changed: got %d, want %d", src.Size(), srcSize)
+	}
+	if _, ok := src.Get(term.NewVariable("new")); ok {
+		t.Errorf("clone's new key leaked to source")
+	}
+	v0, _ := src.Get(term.NewVariable("v0"))
+	c0, _ := term.AsConstant[int](v0)
+	if c0.Value != 0 {
+		t.Errorf("source v0 changed: got %d, want 0", c0.Value)
+	}
+	if _, ok := src.Get(term.NewVariable("v5")); !ok {
+		t.Errorf("source v5 removed by clone's Remove")
+	}
+}
+
+// TestBindingHAMTIterateAll covers Iterate visiting every entry once.
+// HAMT iteration order is bitmap order, not insertion order; we test
+// completeness, not order.
+func TestBindingHAMTIterateAll(t *testing.T) {
+	b := term.NewBinding()
+	const N = 100
+	want := map[string]int{}
+	for i := 0; i < N; i++ {
+		name := fmt.Sprintf("v%d", i)
+		b.Set(term.NewVariable(name), term.NewConstant(i))
+		want[name] = i
+	}
+	got := map[string]int{}
+	b.Iterate(func(k, v term.Term) bool {
+		c, _ := term.AsConstant[int](v)
+		got[k.String()] = c.Value
+		return true
+	})
+	if len(got) != len(want) {
+		t.Fatalf("Iterate visited %d entries, want %d", len(got), len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Iterate(%s) = %d, want %d", k, got[k], v)
+		}
+	}
+}
+
+// TestBindingHAMTEmptyAfterAllRemoved verifies Empty/Size after a full
+// Remove cycle.
+func TestBindingHAMTEmptyAfterAllRemoved(t *testing.T) {
+	b := term.NewBinding()
+	const N = 32
+	for i := 0; i < N; i++ {
+		b.Set(term.NewVariable(fmt.Sprintf("v%d", i)), term.NewConstant(i))
+	}
+	for i := 0; i < N; i++ {
+		b.Remove(term.NewVariable(fmt.Sprintf("v%d", i)))
+	}
+	if !b.Empty() {
+		t.Errorf("Empty after all-Remove: got %d entries", b.Size())
+	}
+}

--- a/term/binding_trail_test.go
+++ b/term/binding_trail_test.go
@@ -1,0 +1,203 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package term_test
+
+import (
+	"testing"
+
+	"github.com/specmon/specmon/term"
+)
+
+// bindingSnapshot returns the binding's contents as a map for
+// deep-equal comparison in tests.
+func bindingSnapshot(b *term.Binding) map[string]string {
+	out := map[string]string{}
+	b.Iterate(func(k, v term.Term) bool {
+		out[k.String()] = v.String()
+		return true
+	})
+	return out
+}
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// TestBindingTrailSetUnwindRoundtrip is the basic Mark/Unwind contract:
+// a single Set followed by Unwind returns the binding to its pre-Set
+// state.
+func TestBindingTrailSetUnwindRoundtrip(t *testing.T) {
+	b := term.NewBinding()
+	b.Set(term.NewVariable("a"), term.NewConstant("1"))
+	before := bindingSnapshot(b)
+
+	trail := term.NewBindingTrail()
+	mark := trail.Mark()
+
+	b.SetWithTrail(term.NewVariable("b"), term.NewConstant("2"), trail)
+	if v, ok := b.Get(term.NewVariable("b")); !ok || v.String() != "'2'" {
+		t.Fatalf("post-Set state wrong: got %v %v", v, ok)
+	}
+
+	b.Unwind(trail, mark)
+	if got := bindingSnapshot(b); !mapsEqual(got, before) {
+		t.Errorf("Unwind did not restore pre-Set state: got %v, want %v", got, before)
+	}
+}
+
+// TestBindingTrailMergeUnwindRoundtrip covers MergeWithTrail: merging
+// in a multi-key other followed by Unwind restores the binding
+// regardless of how many keys were added.
+func TestBindingTrailMergeUnwindRoundtrip(t *testing.T) {
+	b := term.NewBinding()
+	b.Set(term.NewVariable("a"), term.NewConstant("1"))
+	before := bindingSnapshot(b)
+
+	other := term.NewBinding()
+	other.Set(term.NewVariable("b"), term.NewConstant("2"))
+	other.Set(term.NewVariable("c"), term.NewConstant("3"))
+	other.Set(term.NewVariable("d"), term.NewConstant("4"))
+
+	trail := term.NewBindingTrail()
+	mark := trail.Mark()
+
+	b.MergeWithTrail(other, trail)
+	if b.Size() != 4 {
+		t.Fatalf("post-merge size wrong: got %d, want 4", b.Size())
+	}
+
+	b.Unwind(trail, mark)
+	if got := bindingSnapshot(b); !mapsEqual(got, before) {
+		t.Errorf("Unwind did not restore pre-merge state: got %v, want %v", got, before)
+	}
+}
+
+// TestBindingTrailNestedMarks covers the DFS pattern used by
+// conflictSet: push mark, mutate, recurse (push another mark,
+// mutate, unwind), unwind to outer mark. Each unwind level must
+// restore exactly what existed at that mark.
+func TestBindingTrailNestedMarks(t *testing.T) {
+	b := term.NewBinding()
+	b.Set(term.NewVariable("a"), term.NewConstant("1"))
+	s0 := bindingSnapshot(b)
+
+	trail := term.NewBindingTrail()
+	outerMark := trail.Mark()
+	b.SetWithTrail(term.NewVariable("b"), term.NewConstant("2"), trail)
+	s1 := bindingSnapshot(b)
+
+	innerMark := trail.Mark()
+	b.SetWithTrail(term.NewVariable("c"), term.NewConstant("3"), trail)
+	b.SetWithTrail(term.NewVariable("d"), term.NewConstant("4"), trail)
+	if b.Size() != 4 {
+		t.Fatalf("inner size wrong: got %d, want 4", b.Size())
+	}
+
+	// Unwind inner: back to s1.
+	b.Unwind(trail, innerMark)
+	if got := bindingSnapshot(b); !mapsEqual(got, s1) {
+		t.Errorf("inner Unwind: got %v, want %v", got, s1)
+	}
+
+	// Unwind outer: back to s0.
+	b.Unwind(trail, outerMark)
+	if got := bindingSnapshot(b); !mapsEqual(got, s0) {
+		t.Errorf("outer Unwind: got %v, want %v", got, s0)
+	}
+}
+
+// TestBindingTrailUnwindClearsTrail confirms the trail is truncated
+// after Unwind so subsequent Mark/Unwind cycles do not pick up stale
+// snapshots.
+func TestBindingTrailUnwindClearsTrail(t *testing.T) {
+	b := term.NewBinding()
+	trail := term.NewBindingTrail()
+
+	mark1 := trail.Mark()
+	b.SetWithTrail(term.NewVariable("a"), term.NewConstant("1"), trail)
+	b.Unwind(trail, mark1)
+
+	// After unwinding, the next Mark should be at the cleared trail
+	// position. A second cycle must work the same.
+	mark2 := trail.Mark()
+	if mark2 != 0 {
+		t.Errorf("Mark after Unwind: got %d, want 0 (trail should be reset)", mark2)
+	}
+	b.SetWithTrail(term.NewVariable("b"), term.NewConstant("2"), trail)
+	if v, ok := b.Get(term.NewVariable("b")); !ok || v.String() != "'2'" {
+		t.Fatalf("post-second-cycle Set state wrong: got %v %v", v, ok)
+	}
+	b.Unwind(trail, mark2)
+	if !b.Empty() {
+		t.Errorf("second-cycle Unwind did not empty the binding: %v", bindingSnapshot(b))
+	}
+}
+
+// TestBindingTrailMergeWithExistingKey verifies the documented
+// "leftmost wins" semantics of MergeWithTrail: a key already in b is
+// NOT overwritten by other.
+func TestBindingTrailMergeWithExistingKey(t *testing.T) {
+	b := term.NewBinding()
+	b.Set(term.NewVariable("x"), term.NewConstant("original"))
+
+	other := term.NewBinding()
+	other.Set(term.NewVariable("x"), term.NewConstant("override"))
+	other.Set(term.NewVariable("y"), term.NewConstant("new"))
+
+	trail := term.NewBindingTrail()
+	b.MergeWithTrail(other, trail)
+
+	xVal, _ := b.Get(term.NewVariable("x"))
+	if xVal.String() != "'original'" {
+		t.Errorf("MergeWithTrail must keep b's existing value (leftmost wins): got %v", xVal)
+	}
+	yVal, ok := b.Get(term.NewVariable("y"))
+	if !ok || yVal.String() != "'new'" {
+		t.Errorf("MergeWithTrail must add absent keys from other: got %v %v", yVal, ok)
+	}
+}
+
+// TestBindingTrailNoOpOnEmpty covers the trail no-op paths: merging
+// nil or an empty other does nothing and does not push a snapshot.
+func TestBindingTrailNoOpOnEmpty(t *testing.T) {
+	b := term.NewBinding()
+	b.Set(term.NewVariable("a"), term.NewConstant("1"))
+	before := bindingSnapshot(b)
+
+	trail := term.NewBindingTrail()
+	markBefore := trail.Mark()
+
+	b.MergeWithTrail(nil, trail)
+	b.MergeWithTrail(term.NewBinding(), trail)
+
+	if got := bindingSnapshot(b); !mapsEqual(got, before) {
+		t.Errorf("MergeWithTrail(empty) changed b: got %v, want %v", got, before)
+	}
+	if got := trail.Mark(); got != markBefore {
+		t.Errorf("MergeWithTrail(empty) pushed a snapshot: mark went from %d to %d", markBefore, got)
+	}
+}

--- a/term/hamt.go
+++ b/term/hamt.go
@@ -1,0 +1,335 @@
+// Copyright (C) 2025 CISPA Helmholtz Center for Information Security
+// Author: Kevin Morio <kevin.morio@cispa.de>
+//
+// This file is part of SpecMon.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with program. If not, see <https://www.gnu.org/licenses/>.
+
+package term
+
+import "math/bits"
+
+const (
+	hamtBits  = 5
+	hamtWidth = 1 << hamtBits
+	hamtMask  = hamtWidth - 1
+)
+
+type hamtNode struct {
+	bitmap  uint32
+	entries []hamtEntry
+}
+
+type hamtEntry struct {
+	key       Term
+	value     Term
+	child     *hamtNode
+	collision *hamtCollision
+}
+
+type hamtCollision struct {
+	hash    uint64
+	entries []hamtLeaf
+}
+
+type hamtLeaf struct {
+	key   Term
+	value Term
+}
+
+func (n *hamtNode) get(k Term, hash uint64, shift uint) (Term, bool) {
+	if n == nil {
+		return nil, false
+	}
+	bit := hamtBit(hash, shift)
+	if n.bitmap&bit == 0 {
+		return nil, false
+	}
+	idx := hamtIndex(n.bitmap, bit)
+	entry := n.entries[idx]
+	if entry.key != nil {
+		if entry.key == k || entry.key.Equal(k) {
+			return entry.value, true
+		}
+		return nil, false
+	}
+	if entry.collision != nil {
+		return entry.collision.get(k)
+	}
+	return entry.child.get(k, hash, shift+hamtBits)
+}
+
+func (n *hamtNode) set(k, v Term, hash uint64, shift uint) (*hamtNode, bool) {
+	if n == nil {
+		bit := hamtBit(hash, shift)
+		return &hamtNode{
+			bitmap:  bit,
+			entries: []hamtEntry{{key: k, value: v}},
+		}, true
+	}
+	bit := hamtBit(hash, shift)
+	idx := hamtIndex(n.bitmap, bit)
+
+	if n.bitmap&bit == 0 {
+		return n.insertAt(idx, bit, hamtEntry{key: k, value: v}), true
+	}
+
+	entry := n.entries[idx]
+	switch {
+	case entry.key != nil:
+		if entry.key == k || entry.key.Equal(k) {
+			if entry.value.Equal(v) {
+				return n, false
+			}
+			return n.updateAt(idx, hamtEntry{key: entry.key, value: v}), false
+		}
+		entryHash := entry.key.Hash()
+		if entryHash == hash {
+			collision := newCollision(entryHash, entry.key, entry.value, k, v)
+			return n.updateAt(idx, hamtEntry{collision: collision}), true
+		}
+		child := newSubNodeWithTwo(entry.key, entry.value, entryHash, k, v, hash, shift+hamtBits)
+		return n.updateAt(idx, hamtEntry{child: child}), true
+	case entry.collision != nil:
+		collision, added := entry.collision.set(k, v)
+		if collision == entry.collision {
+			return n, added
+		}
+		return n.updateAt(idx, hamtEntry{collision: collision}), added
+	case entry.child != nil:
+		child, added := entry.child.set(k, v, hash, shift+hamtBits)
+		if child == entry.child {
+			return n, added
+		}
+		return n.updateAt(idx, hamtEntry{child: child}), added
+	default:
+		return n, false
+	}
+}
+
+func (n *hamtNode) remove(k Term, hash uint64, shift uint) (*hamtNode, bool) {
+	if n == nil {
+		return nil, false
+	}
+	bit := hamtBit(hash, shift)
+	if n.bitmap&bit == 0 {
+		return n, false
+	}
+	idx := hamtIndex(n.bitmap, bit)
+	entry := n.entries[idx]
+
+	switch {
+	case entry.key != nil:
+		if entry.key == k || entry.key.Equal(k) {
+			return n.removeAt(idx, bit), true
+		}
+		return n, false
+	case entry.collision != nil:
+		collision, removed := entry.collision.remove(k)
+		if !removed {
+			return n, false
+		}
+		if collision == nil || len(collision.entries) == 0 {
+			return n.removeAt(idx, bit), true
+		}
+		if len(collision.entries) == 1 {
+			leaf := collision.entries[0]
+			return n.updateAt(idx, hamtEntry{key: leaf.key, value: leaf.value}), true
+		}
+		return n.updateAt(idx, hamtEntry{collision: collision}), true
+	case entry.child != nil:
+		child, removed := entry.child.remove(k, hash, shift+hamtBits)
+		if !removed {
+			return n, false
+		}
+		if child == nil || len(child.entries) == 0 {
+			return n.removeAt(idx, bit), true
+		}
+		if leaf, ok := child.singleLeaf(); ok {
+			return n.updateAt(idx, leaf), true
+		}
+		return n.updateAt(idx, hamtEntry{child: child}), true
+	default:
+		return n, false
+	}
+}
+
+func (n *hamtNode) iterate(f func(Term, Term) bool) bool {
+	if n == nil {
+		return true
+	}
+	for _, entry := range n.entries {
+		switch {
+		case entry.key != nil:
+			if !f(entry.key, entry.value) {
+				return false
+			}
+		case entry.collision != nil:
+			if !entry.collision.iterate(f) {
+				return false
+			}
+		case entry.child != nil:
+			if !entry.child.iterate(f) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (n *hamtNode) insertAt(idx int, bit uint32, entry hamtEntry) *hamtNode {
+	entries := make([]hamtEntry, len(n.entries)+1)
+	copy(entries, n.entries[:idx])
+	entries[idx] = entry
+	copy(entries[idx+1:], n.entries[idx:])
+	return &hamtNode{
+		bitmap:  n.bitmap | bit,
+		entries: entries,
+	}
+}
+
+func (n *hamtNode) updateAt(idx int, entry hamtEntry) *hamtNode {
+	entries := make([]hamtEntry, len(n.entries))
+	copy(entries, n.entries)
+	entries[idx] = entry
+	return &hamtNode{
+		bitmap:  n.bitmap,
+		entries: entries,
+	}
+}
+
+func (n *hamtNode) removeAt(idx int, bit uint32) *hamtNode {
+	if len(n.entries) == 1 {
+		return nil
+	}
+	entries := make([]hamtEntry, len(n.entries)-1)
+	copy(entries, n.entries[:idx])
+	copy(entries[idx:], n.entries[idx+1:])
+	return &hamtNode{
+		bitmap:  n.bitmap &^ bit,
+		entries: entries,
+	}
+}
+
+func (n *hamtNode) singleLeaf() (hamtEntry, bool) {
+	if n == nil || len(n.entries) != 1 {
+		return hamtEntry{}, false
+	}
+	entry := n.entries[0]
+	if entry.key != nil {
+		return entry, true
+	}
+	return hamtEntry{}, false
+}
+
+func hamtBit(hash uint64, shift uint) uint32 {
+	return uint32(1) << ((hash >> shift) & hamtMask)
+}
+
+func hamtIndex(bitmap, bit uint32) int {
+	return bits.OnesCount32(bitmap & (bit - 1))
+}
+
+func newCollision(hash uint64, k1, v1, k2, v2 Term) *hamtCollision {
+	return &hamtCollision{
+		hash: hash,
+		entries: []hamtLeaf{
+			{key: k1, value: v1},
+			{key: k2, value: v2},
+		},
+	}
+}
+
+func (c *hamtCollision) get(k Term) (Term, bool) {
+	if c == nil {
+		return nil, false
+	}
+	for _, entry := range c.entries {
+		if entry.key == k || entry.key.Equal(k) {
+			return entry.value, true
+		}
+	}
+	return nil, false
+}
+
+func (c *hamtCollision) set(k, v Term) (*hamtCollision, bool) {
+	for i, entry := range c.entries {
+		if entry.key == k || entry.key.Equal(k) {
+			if entry.value.Equal(v) {
+				return c, false
+			}
+			entries := make([]hamtLeaf, len(c.entries))
+			copy(entries, c.entries)
+			entries[i] = hamtLeaf{key: entry.key, value: v}
+			return &hamtCollision{hash: c.hash, entries: entries}, false
+		}
+	}
+	entries := make([]hamtLeaf, len(c.entries)+1)
+	copy(entries, c.entries)
+	entries[len(c.entries)] = hamtLeaf{key: k, value: v}
+	return &hamtCollision{hash: c.hash, entries: entries}, true
+}
+
+func (c *hamtCollision) remove(k Term) (*hamtCollision, bool) {
+	for i, entry := range c.entries {
+		if entry.key == k || entry.key.Equal(k) {
+			if len(c.entries) == 1 {
+				return nil, true
+			}
+			entries := make([]hamtLeaf, len(c.entries)-1)
+			copy(entries, c.entries[:i])
+			copy(entries[i:], c.entries[i+1:])
+			return &hamtCollision{hash: c.hash, entries: entries}, true
+		}
+	}
+	return c, false
+}
+
+func (c *hamtCollision) iterate(f func(Term, Term) bool) bool {
+	for _, entry := range c.entries {
+		if !f(entry.key, entry.value) {
+			return false
+		}
+	}
+	return true
+}
+
+func newSubNodeWithTwo(k1, v1 Term, h1 uint64, k2, v2 Term, h2 uint64, shift uint) *hamtNode {
+	if h1 == h2 {
+		bit := hamtBit(h1, shift)
+		return &hamtNode{
+			bitmap:  bit,
+			entries: []hamtEntry{{collision: newCollision(h1, k1, v1, k2, v2)}},
+		}
+	}
+	bit1 := hamtBit(h1, shift)
+	bit2 := hamtBit(h2, shift)
+	if bit1 != bit2 {
+		entries := make([]hamtEntry, 0, 2)
+		if bit1 < bit2 {
+			entries = append(entries, hamtEntry{key: k1, value: v1}, hamtEntry{key: k2, value: v2})
+		} else {
+			entries = append(entries, hamtEntry{key: k2, value: v2}, hamtEntry{key: k1, value: v1})
+		}
+		return &hamtNode{
+			bitmap:  bit1 | bit2,
+			entries: entries,
+		}
+	}
+	child := newSubNodeWithTwo(k1, v1, h1, k2, v2, h2, shift+hamtBits)
+	return &hamtNode{
+		bitmap:  bit1,
+		entries: []hamtEntry{{child: child}},
+	}
+}

--- a/term/term.go
+++ b/term/term.go
@@ -924,12 +924,12 @@ func UnifyReplace(t, g, h Term) Term {
 		return SubstBinding(b, h)
 	}
 
-	u := NewFunction(f.Name, make([]Term, len(f.Args)))
+	args := make([]Term, len(f.Args))
 	for i, s := range f.Args {
-		u.Args[i] = UnifyReplace(s, g, h)
+		args[i] = UnifyReplace(s, g, h)
 	}
 
-	return u
+	return NewFunction(f.Name, args)
 }
 
 func UnifyReplaceRecursive(t, g, h Term) Term {

--- a/term/term.go
+++ b/term/term.go
@@ -182,9 +182,9 @@ func NewFunction(name string, args []Term) *Function {
 func (c *Constant[T]) Equal(t Term) bool {
 	// Fast path: when t is a Constant of the same generic
 	// instantiation (T) compare typed values directly. Avoids the
-	// AsBytes allocation each side previously paid (utils.IntToBytes
+	// AsBytes allocation each side otherwise pays (utils.IntToBytes
 	// for int constants, []byte(string) for string constants), which
-	// dominated Fact.Equal cost in the hot configSet / conflictSet
+	// dominated Fact.Equal cost in the hot config-dedup / conflictSet
 	// paths.
 	if other, ok := any(t).(*Constant[T]); ok {
 		switch v1 := any(c.Value).(type) {
@@ -293,9 +293,9 @@ func (f *Function) String() string {
 // value bytes. Recomputed on every call - terms are mutable through
 // exported fields (Value), so any cache would risk going stale on
 // post-construction mutation. The recompute is one FNV pass over a
-// short byte slice; profiling showed the prior lazy cache won at most
-// a few percent and was the source of a data race (concurrent calls
-// raced on the cache write).
+// short byte slice; profiling showed a lazy cache wins at most a few
+// percent while introducing a data race (concurrent calls racing on
+// the cache write).
 func (c *Constant[T]) Hash() uint64 {
 	h := fnv.New64a()
 

--- a/term/term.go
+++ b/term/term.go
@@ -180,16 +180,38 @@ func NewFunction(name string, args []Term) *Function {
 }
 
 func (c *Constant[T]) Equal(t Term) bool {
+	// Fast path: when t is a Constant of the same generic
+	// instantiation (T) compare typed values directly. Avoids the
+	// AsBytes allocation each side previously paid (utils.IntToBytes
+	// for int constants, []byte(string) for string constants), which
+	// dominated Fact.Equal cost in the hot configSet / conflictSet
+	// paths.
+	if other, ok := any(t).(*Constant[T]); ok {
+		switch v1 := any(c.Value).(type) {
+		case int:
+			v2 := any(other.Value).(int)
+			return v1 == v2
+		case string:
+			v2 := any(other.Value).(string)
+			return v1 == v2
+		case []byte:
+			v2 := any(other.Value).([]byte)
+			return bytes.Equal(v1, v2)
+		}
+	}
+
+	// Slow path: t has a different ConstantConstraint instantiation
+	// (e.g. comparing *Constant[int] to *Constant[[]byte]). Fall back
+	// to byte-wise equality through AsBytes so heterogeneous constants
+	// that share a byte representation still compare equal.
 	b1, err := AsBytes(c)
 	if err != nil {
 		return false
 	}
-
 	b2, err := AsBytes(t)
 	if err != nil {
 		return false
 	}
-
 	return bytes.Equal(b1, b2)
 }
 

--- a/term/term.go
+++ b/term/term.go
@@ -267,6 +267,13 @@ func (f *Function) String() string {
 	return fmt.Sprintf("%s%s%s%s", fName, openDelim, str, closeDelim)
 }
 
+// Hash returns a 64-bit FNV-1a digest of the constant's type tag and
+// value bytes. Recomputed on every call - terms are mutable through
+// exported fields (Value), so any cache would risk going stale on
+// post-construction mutation. The recompute is one FNV pass over a
+// short byte slice; profiling showed the prior lazy cache won at most
+// a few percent and was the source of a data race (concurrent calls
+// raced on the cache write).
 func (c *Constant[T]) Hash() uint64 {
 	h := fnv.New64a()
 
@@ -285,6 +292,8 @@ func (c *Constant[T]) Hash() uint64 {
 	return h.Sum64()
 }
 
+// Hash returns a 64-bit FNV-1a digest of the variable's name and type
+// tag. Recomputed on every call; see Constant.Hash for rationale.
 func (v *Variable) Hash() uint64 {
 	h := fnv.New64a()
 
@@ -294,6 +303,16 @@ func (v *Variable) Hash() uint64 {
 	return h.Sum64()
 }
 
+// Hash returns a 64-bit FNV-1a digest of the function's name, type
+// tag, and the recursively-hashed args. Recomputed on every call; see
+// Constant.Hash for rationale.
+//
+// Cost note: a deeply nested Function costs O(total subterms) FNV
+// work per call. In the monitor hot path each Function is built from
+// freshly-constructed args and hashed once via Fact.Hash, which IS
+// cached on the fact wrapper (rule/fact.go). Variables that recur
+// across many facts are cheap to rehash because their hash input is
+// just (name, type) bytes.
 func (f *Function) Hash() uint64 {
 	h := fnv.New64a()
 	h.Write([]byte(f.Name))


### PR DESCRIPTION
Reworks the monitor's hot path (conflict-set matching, per-Config fact storage, and the binding representation) for a substantial speed and memory improvement, building on the conflict-set indexing merged in #73.

Main changes:

- **term:** HAMT-backed `Binding` with an O(1) `Clone` and a snapshot-based trail, replacing the HashMap representation; lazy map allocation.
- **monitor:** an LHS predicate-count applicability gate that skips rules that cannot fire; per-predicate fact bucketing on `Config` with copy-on-write clone; cached `Fact`/`Config` hashes; rule dispatch split into `(name, arity)` buckets; synchronous rule-action returns instead of per-Config channels.

Includes two soundness fixes surfaced during review:

- Trigger matching is anchored to the current event, so a trigger slot for the arriving event can no longer be filled by an older buffered event (the prior behavior admitted applications that never consumed the current event). Pinned by `TestMonitorTriggerAnchoredToCurrentEvent`.
- Rules are registered once per trigger/hint signature key, so a rule with two same-signature triggers no longer emits its actions twice. Pinned by `TestMonitorSameSignatureTriggersRegisteredOnce`.

Known out of scope: multi-trigger rules still check their LHS at completion time rather than at first-trigger time, tracked separately.

The series substantially reduces both wall time and peak memory on the monitoring workloads it was developed against. The exact gains are workload-dependent.